### PR TITLE
creates initial version for backend SPI

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/Main.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/Main.java
@@ -16,6 +16,7 @@
 package com.sebastian_daschner.jaxrs_analyzer;
 
 import com.sebastian_daschner.jaxrs_analyzer.backend.Backend;
+import com.sebastian_daschner.jaxrs_analyzer.backend.swagger.SwaggerBackend;
 import com.sebastian_daschner.jaxrs_analyzer.backend.swagger.SwaggerBackendBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.backend.swagger.SwaggerScheme;
 
@@ -23,8 +24,11 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,13 +45,10 @@ public class Main {
 
     private static final Set<Path> projectPaths = new HashSet<>();
     private static final Set<Path> classPaths = new HashSet<>();
+    private static final Map<String, String> attributes = new HashMap<>();
     private static String name = DEFAULT_NAME;
     private static String version = DEFAULT_VERSION;
-    private static BackendType backendType = BackendType.SWAGGER;
-    private static String domain;
-    private static Set<SwaggerScheme> swaggerSchemes;
-    private static Boolean renderSwaggerTags;
-    private static Integer swaggerTagsPathOffset;
+    private static String backendType = "swagger";
     private static Path outputFileLocation;
 
     /**
@@ -91,7 +92,8 @@ public class Main {
 
         validateArgs();
 
-        final Backend backend = constructBackend();
+        final Backend backend = constructBackend(backendType);
+        backend.configure(attributes);
 
         final JAXRSAnalyzer jaxrsAnalyzer = new JAXRSAnalyzer(projectPaths, classPaths, name, version, backend, outputFileLocation);
         jaxrsAnalyzer.analyze();
@@ -118,19 +120,22 @@ public class Main {
                             version = args[++i];
                             break;
                         case "-d":
-                            domain = args[++i];
+                            attributes.put(SwaggerBackend.DOMAIN, args[++i]);
                             break;
                         case "-o":
                             outputFileLocation = Paths.get(args[++i]);
                             break;
                         case "--swaggerSchemes":
-                            swaggerSchemes = extractSwaggerSchemes(args[++i]);
+                            attributes.put(SwaggerBackend.SWAGGER_SCHEMES, args[++i]);
                             break;
                         case "--renderSwaggerTags":
-                            renderSwaggerTags = true;
+                            attributes.put(SwaggerBackend.RENDER_SWAGGER_TAGS, "true");
                             break;
                         case "--swaggerTagsPathOffset":
-                            swaggerTagsPathOffset = Integer.valueOf(args[++i]);
+                            attributes.put(SwaggerBackend.SWAGGER_TAGS_PATH_OFFSET, args[++i]);
+                            break;
+                        case "-a":
+                            addAttribute(args[++i]);
                             break;
                         default:
                             throw new IllegalArgumentException("Unknown option " + args[i]);
@@ -149,17 +154,20 @@ public class Main {
         }
     }
 
-    private static BackendType extractBackend(final String name) {
-        switch (name.toLowerCase()) {
-            case "swagger":
-                return BackendType.SWAGGER;
-            case "plaintext":
-                return BackendType.PLAINTEXT;
-            case "asciidoc":
-                return BackendType.ASCIIDOC;
-            default:
-                throw new IllegalArgumentException("Unknown backend " + name);
+    static Map<String, String> addAttribute(String attribute) {
+        int separatorIndex = attribute.indexOf('=');
+
+        if (separatorIndex < 0) {
+            attributes.put(attribute, "");
+        } else {
+            attributes.put(attribute.substring(0, separatorIndex).trim(), attribute.substring(separatorIndex + 1).trim());
         }
+
+        return attributes;
+    }
+
+    private static String extractBackend(final String name) {
+        return name.toLowerCase();
     }
 
     private static List<Path> extractClassPaths(final String classPaths) {
@@ -174,32 +182,8 @@ public class Main {
         return paths;
     }
 
-    private static Set<SwaggerScheme> extractSwaggerSchemes(final String schemes) {
-        return Stream.of(schemes.split(","))
-                .map(Main::extractSwaggerScheme)
-                .collect(() -> EnumSet.noneOf(SwaggerScheme.class), Set::add, Set::addAll);
-    }
-
-    private static SwaggerScheme extractSwaggerScheme(final String scheme) {
-        switch (scheme.toLowerCase()) {
-            case "http":
-                return SwaggerScheme.HTTP;
-            case "https":
-                return SwaggerScheme.HTTPS;
-            case "ws":
-                return SwaggerScheme.WS;
-            case "wss":
-                return SwaggerScheme.WSS;
-            default:
-                throw new IllegalArgumentException("Unknown swagger scheme " + scheme);
-        }
-    }
 
     private static void validateArgs() {
-        if (swaggerTagsPathOffset != null && swaggerTagsPathOffset < 0) {
-            System.err.println("Please provide positive integer number for option --swaggerTagsPathOffset\n");
-            printUsageAndExit();
-        }
 
         if (projectPaths.isEmpty()) {
             System.err.println("Please provide at least one project path\n");
@@ -207,35 +191,17 @@ public class Main {
         }
     }
 
-    private static Backend constructBackend() {
-        switch (backendType) {
-            case SWAGGER:
-                return configureSwaggerBackend();
-            case PLAINTEXT:
-                return Backend.plainText().build();
-            case ASCIIDOC:
-                return Backend.asciiDoc().build();
-            default:
-                // can not happen
-                throw new IllegalArgumentException("Unknown backend type " + backendType);
-        }
-    }
+    static Backend constructBackend(String backendType) {
 
-    private static Backend configureSwaggerBackend() {
-        final SwaggerBackendBuilder builder = Backend.swagger();
+        final ServiceLoader<Backend> backends = ServiceLoader.load(Backend.class);
 
-        if (domain != null)
-            builder.domain(domain);
-        if (swaggerSchemes != null)
-            builder.schemes(swaggerSchemes);
-        if (renderSwaggerTags != null) {
-            if (swaggerTagsPathOffset != null)
-                builder.renderTags(renderSwaggerTags, swaggerTagsPathOffset);
-            else
-                builder.renderTags(renderSwaggerTags);
+        for (Backend backend : backends) {
+            if (backendType.equalsIgnoreCase(backend.getName())) {
+                return backend;
+            }
         }
 
-        return builder.build();
+        throw new IllegalArgumentException("Unknown backend type " + backendType);
     }
 
     private static void printUsageAndExit() {
@@ -249,6 +215,7 @@ public class Main {
         System.err.println(" -v <project version> The version of the project");
         System.err.println(" -d <project domain> The domain of the project");
         System.err.println(" -o <output file> The location of the analysis output (will be printed to standard out if omitted)");
+        System.err.println(" -a <attribute name>=<attribute value> Set custom attributes for backends.");
         System.err.println("\nFollowing available backend specific options (only have effect if the corresponding backend is selected):\n");
         System.err.println(" --swaggerSchemes <scheme>[,schemes] The Swagger schemes: http (default), https, ws, wss");
         System.err.println(" --renderSwaggerTags Enables rendering of Swagger tags (default tag will be used per default)");
@@ -257,7 +224,4 @@ public class Main {
         System.exit(1);
     }
 
-    private enum BackendType {
-        SWAGGER, PLAINTEXT, ASCIIDOC
-    }
 }

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/Backend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/Backend.java
@@ -21,6 +21,8 @@ import com.sebastian_daschner.jaxrs_analyzer.backend.plaintext.PlainTextBackendB
 import com.sebastian_daschner.jaxrs_analyzer.backend.swagger.SwaggerBackendBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.Project;
 
+import java.util.Map;
+
 /**
  * Renders the analyzed JAX-RS resources into a String representation.
  *
@@ -40,6 +42,12 @@ public interface Backend {
      * Returns a human readable name of the actual backend.
      */
     String getName();
+
+    /**
+     * Method used for configuring Backend.
+     * @param config values.
+     */
+    default void configure(Map<String, String> config) {}
 
     /**
      * Creates a builder for Swagger backend.

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
@@ -22,7 +22,7 @@ import static com.sebastian_daschner.jaxrs_analyzer.model.JavaUtils.toReadableTy
  *
  * @author Sebastian Daschner
  */
-class AsciiDocBackend implements Backend {
+public class AsciiDocBackend implements Backend {
 
     private static final String NAME = "AsciiDoc";
     private static final String DOCUMENT_TITLE = "= REST resources of ";
@@ -34,6 +34,10 @@ class AsciiDocBackend implements Backend {
     private String projectName;
     private String projectVersion;
     private TypeRepresentationVisitor visitor;
+
+    public AsciiDocBackend() {
+        super();
+    }
 
     @Override
     public String render(final Project project) {

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackend.java
@@ -38,9 +38,9 @@ import static java.util.Comparator.comparing;
  *
  * @author Sebastian Daschner
  */
-class PlainTextBackend implements Backend {
+public class PlainTextBackend implements Backend {
 
-    private static final String NAME = "Plain text";
+    private static final String NAME = "PlainText";
     private static final String REST_HEADER = "REST resources of ";
     private static final String TYPE_WILDCARD = "*/*";
 

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
@@ -17,19 +17,29 @@
 package com.sebastian_daschner.jaxrs_analyzer.backend.swagger;
 
 import com.sebastian_daschner.jaxrs_analyzer.backend.Backend;
-import com.sebastian_daschner.jaxrs_analyzer.model.rest.*;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.MethodParameter;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.ParameterType;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.Project;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.ResourceMethod;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.Resources;
 
-import javax.json.*;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonWriter;
 import javax.json.stream.JsonGenerator;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 import static com.sebastian_daschner.jaxrs_analyzer.backend.ComparatorUtils.mapKeyComparator;
 import static com.sebastian_daschner.jaxrs_analyzer.backend.ComparatorUtils.parameterComparator;
@@ -41,7 +51,12 @@ import static java.util.Comparator.comparing;
  *
  * @author Sebastian Daschner
  */
-class SwaggerBackend implements Backend {
+public class SwaggerBackend implements Backend {
+
+    public static final String SWAGGER_SCHEMES = "swaggerSchemes";
+    public static final String RENDER_SWAGGER_TAGS = "renderSwaggerTags";
+    public static final String SWAGGER_TAGS_PATH_OFFSET = "swaggerTagsPathOffset";
+    public static final String DOMAIN = "domain";
 
     private static final String NAME = "Swagger";
     private static final String SWAGGER_VERSION = "2.0";
@@ -53,6 +68,10 @@ class SwaggerBackend implements Backend {
     private SchemaBuilder schemaBuilder;
     private String projectName;
     private String projectVersion;
+
+    public SwaggerBackend() {
+        this(new SwaggerOptions());
+    }
 
     SwaggerBackend(final SwaggerOptions options) {
         this.options = options;
@@ -203,9 +222,59 @@ class SwaggerBackend implements Backend {
         builder.add("definitions", schemaBuilder.getDefinitions());
     }
 
+
+
+    private SwaggerScheme extractSwaggerScheme(final String scheme) {
+        switch (scheme.toLowerCase()) {
+            case "http":
+                return SwaggerScheme.HTTP;
+            case "https":
+                return SwaggerScheme.HTTPS;
+            case "ws":
+                return SwaggerScheme.WS;
+            case "wss":
+                return SwaggerScheme.WSS;
+            default:
+                throw new IllegalArgumentException("Unknown swagger scheme " + scheme);
+        }
+    }
+
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public void configure(Map<String, String> config) {
+        if (config.containsKey(SWAGGER_TAGS_PATH_OFFSET)) {
+            Integer swaggerTagsPathOffset = Integer.parseInt(config.get(SWAGGER_TAGS_PATH_OFFSET));
+
+            if (swaggerTagsPathOffset < 0) {
+                System.err.println("Please provide positive integer number for option --swaggerTagsPathOffset\n");
+                throw new IllegalArgumentException("Please provide positive integer number for option --swaggerTagsPathOffset");
+            }
+
+            this.options.setTagsPathOffset(swaggerTagsPathOffset);
+        }
+
+        if(config.containsKey(DOMAIN)) {
+            this.options.setDomain(config.get(DOMAIN));
+        }
+
+        if (config.containsKey(SWAGGER_SCHEMES)) {
+            this.options.setSchemes(extractSwaggerSchemes(config.get(SWAGGER_SCHEMES)));
+        }
+
+        if (config.containsKey(RENDER_SWAGGER_TAGS)) {
+            this.options.setRenderTags(Boolean.parseBoolean(config.get(RENDER_SWAGGER_TAGS)));
+        }
+    }
+
+
+    private Set<SwaggerScheme> extractSwaggerSchemes(final String schemes) {
+        return Stream.of(schemes.split(","))
+                .map(this::extractSwaggerScheme)
+                .collect(() -> EnumSet.noneOf(SwaggerScheme.class), Set::add, Set::addAll);
     }
 
     private static String getSwaggerParameterType(final ParameterType parameterType) {

--- a/src/main/resources/META-INF/services/com.sebastian_daschner.jaxrs_analyzer.backend.Backend
+++ b/src/main/resources/META-INF/services/com.sebastian_daschner.jaxrs_analyzer.backend.Backend
@@ -1,0 +1,3 @@
+com.sebastian_daschner.jaxrs_analyzer.backend.asciidoc.AsciiDocBackend
+com.sebastian_daschner.jaxrs_analyzer.backend.plaintext.PlainTextBackend
+com.sebastian_daschner.jaxrs_analyzer.backend.swagger.SwaggerBackend

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/MainTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/MainTest.java
@@ -1,0 +1,56 @@
+package com.sebastian_daschner.jaxrs_analyzer;
+
+import com.sebastian_daschner.jaxrs_analyzer.backend.Backend;
+import com.sebastian_daschner.jaxrs_analyzer.backend.asciidoc.AsciiDocBackend;
+import com.sebastian_daschner.jaxrs_analyzer.backend.plaintext.PlainTextBackend;
+import com.sebastian_daschner.jaxrs_analyzer.backend.swagger.SwaggerBackend;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class MainTest {
+
+    @Test
+    public void shouldAddBinaryAttributes() {
+        final Map<String, String> conf = Main.addAttribute("att1 = val1");
+        assertThat(conf.containsKey("att1"), is(true));
+        assertThat(conf.get("att1"), is("val1"));
+    }
+
+    @Test
+    public void shouldAddSingleAttributes() {
+        final Map<String, String> conf = Main.addAttribute("att1");
+        assertThat(conf.containsKey("att1"), is(true));
+        assertThat(conf.get("att1"), is(""));
+    }
+
+    @Test
+    public void shouldAddEmptyAttributeValues() {
+        final Map<String, String> conf = Main.addAttribute("att1=");
+        assertThat(conf.containsKey("att1"), is(true));
+        assertThat(conf.get("att1"), is(""));
+    }
+
+    @Test
+    public void shouldLoadSwaggerFromJavaService() {
+        final Backend backend = Main.constructBackend("swagger");
+        assertThat(backend, is(instanceOf(SwaggerBackend.class)));
+    }
+
+    @Test
+    public void shouldLoadPlainTextFromJavaService() {
+        final Backend backend = Main.constructBackend("plaintext");
+        assertThat(backend, is(instanceOf(PlainTextBackend.class)));
+    }
+
+    @Test
+    public void shouldLoadAsciiDocFromJavaService() {
+        final Backend backend = Main.constructBackend("asciidoc");
+        assertThat(backend, is(instanceOf(AsciiDocBackend.class)));
+    }
+
+}


### PR DESCRIPTION
Creates initial version for backend SPI.

I would do some more changes, for example creating a Maven module called `core`, `api` (for model) and `spi` (for backend interface) but since this could means a break back compatibility (artifact names for example), I leave this so you can take the correct decision.

Fixes #76 