### PR TITLE
Allows empty host in swagger backend

### DIFF
--- a/Changelog.adoc
+++ b/Changelog.adoc
@@ -3,6 +3,10 @@ Sebastian Daschner
 
 // new versions are placed on the top
 
+== v0.13
+- Support empty domain (https://github.com/sdaschner/jaxrs-analyzer/issues/42[#42^])
+- Output dir is now editable in maven plugin (https://github.com/sdaschner/jaxrs-analyzer-maven-plugin/issues/13[#13^])
+
 == v0.12
 - Fixed JavaDoc related class loading
 

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
@@ -97,7 +97,7 @@ public class SwaggerBackend implements Backend {
     private void appendHeader() {
         builder.add("swagger", SWAGGER_VERSION).add("info", Json.createObjectBuilder()
                 .add("version", projectVersion).add("title", projectName))
-                .add("host", options.getDomain()).add("basePath", '/' + resources.getBasePath())
+                .add("host", options.getDomain() == null ? "" : options.getDomain()).add("basePath", (options.getDomain() != null && !"".equals(options.getDomain().trim()) ? '/' : '/' + projectName + '/') + resources.getBasePath())
                 .add("schemes", options.getSchemes().stream().map(Enum::name).map(String::toLowerCase).sorted()
                         .collect(Json::createArrayBuilder, JsonArrayBuilder::add, JsonArrayBuilder::add).build());
         if (options.isRenderTags()) {

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerOptions.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerOptions.java
@@ -25,7 +25,7 @@ public class SwaggerOptions {
     public static final String SWAGGER_TAGS_PATH_OFFSET = "swaggerTagsPathOffset";
     public static final String JSON_PATCH = "jsonPatch";
 
-    private static final String DEFAULT_DOMAIN = "example.com";
+    private static final String DEFAULT_DOMAIN = "";
     private static final Set<SwaggerScheme> DEFAULT_SCHEMES = EnumSet.of(SwaggerScheme.HTTP);
     private static final boolean DEFAULT_RENDER_TAGS = false;
     private static final int DEFAULT_TAGS_PATH_OFFSET = 0;

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
@@ -69,6 +69,7 @@ public class SwaggerBackendTest {
         }
     }
 
+
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         final Collection<Object[]> data = new LinkedList<>();
@@ -81,10 +82,11 @@ public class SwaggerBackendTest {
         add(data, ResourcesBuilder.withBase("rest")
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
-                "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res1\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{\"Location\":{\"type\":\"string\"}},\"schema\":{\"type\":\"string\"}}}}}},\"definitions\":{}}");
+                "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"\",\"basePath\":\"/project name/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res1\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{\"Location\":{\"type\":\"string\"}},\"schema\":{\"type\":\"string\"}}}}}},\"definitions\":{}}",new HashMap<>());
 
         Map<String, String> options = new HashMap<>();
         options.put(SWAGGER_SCHEMES, "https,wss");
+        options.put(DOMAIN,"example.com");
         add(data, ResourcesBuilder.withBase("rest")
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
@@ -169,6 +171,7 @@ public class SwaggerBackendTest {
 
         options = new HashMap<>();
         options.put(RENDER_SWAGGER_TAGS, "true");
+        options.put(DOMAIN, "example.com");
         options.put(SWAGGER_TAGS_PATH_OFFSET, "1");
         add(data, ResourcesBuilder.withBase("rest")
                         .andResource("v2/res11", ResourceMethodBuilder.withMethod(HttpMethod.GET)
@@ -235,7 +238,9 @@ public class SwaggerBackendTest {
     }
 
     public static void add(final Collection<Object[]> data, final Resources resources, final String output) {
-        add(data, resources, output, new HashMap<>());
+        Map<String, String> options = new HashMap<>();
+        options.put(DOMAIN,"example.com");
+        add(data, resources, output, options);
     }
 
     public static void add(final Collection<Object[]> data, final Resources resources, final String output, final Map<String, String> options) {


### PR DESCRIPTION
As discussed in #42, it is easier to support multiple domains if host is empty in swagger spec so tools like swaggerUI can resolve domain automatically. 

**Breaking changes:**

Now _domain_ default value is empty string ("") instead of "example.com" 