### PR TITLE
Ability to ignore fields and type using Jackson Annotations

### DIFF
--- a/Changelog.adoc
+++ b/Changelog.adoc
@@ -6,6 +6,7 @@ Sebastian Daschner
 == v0.13
 - Support empty domain (https://github.com/sdaschner/jaxrs-analyzer/issues/42[#42^])
 - Output dir is now editable in maven plugin (https://github.com/sdaschner/jaxrs-analyzer-maven-plugin/issues/13[#13^])
+- Ignore properties in representations via Jackson annotations (https://github.com/sdaschner/jaxrs-analyzer/issues/87[#87^])
 
 == v0.12
 - Fixed JavaDoc related class loading

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>asm-all</artifactId>
             <version>5.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.8.5</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass22.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass22.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 Sebastian Daschner, sebastian-daschner.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.sebastian_daschner.jaxrs_analyzer.analysis.results.testclasses.typeanalyzer;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils;
+import com.sebastian_daschner.jaxrs_analyzer.model.Types;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test @JsonIgnore on primitive field
+ */
+public class TestClass22 {
+
+    private static String PRIVATE_FIELD;
+    public static String PUBLIC_FIELD;
+    private String privateField;
+    protected String protectedField;
+    @JsonIgnore
+    public String publicField;
+
+    public String getTest() {
+        return null;
+    }
+
+    public int getInt() {
+        return 0;
+    }
+
+    public static String getStaticString() {
+        return null;
+    }
+
+    public String string() {
+        return null;
+    }
+
+    public static Set<TypeRepresentation> expectedTypeRepresentations() {
+        final Map<String, TypeIdentifier> properties = new HashMap<>();
+
+
+        // properties.put("publicField", TypeUtils.STRING_IDENTIFIER); //ignored by @JsonIgnore
+        properties.put("test", TypeUtils.STRING_IDENTIFIER);
+        properties.put("int", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
+
+        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+    }
+
+    public static TypeIdentifier expectedIdentifier() {
+        return TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass22;");
+    }
+
+}

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass23.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass23.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Sebastian Daschner, sebastian-daschner.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.sebastian_daschner.jaxrs_analyzer.analysis.results.testclasses.typeanalyzer;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sebastian_daschner.jaxrs_analyzer.model.Types;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test @JsonIgnore on type field
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TestClass23 {
+
+    private boolean first;
+    private int second;
+    @JsonIgnore
+    private TestClass23 child;
+
+    public static Set<TypeRepresentation> expectedTypeRepresentations() {
+        final Map<String, TypeIdentifier> properties = new HashMap<>();
+
+        final TypeIdentifier identifier = expectedIdentifier();
+        properties.put("first", TypeIdentifier.ofType(Types.PRIMITIVE_BOOLEAN));
+        properties.put("second", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
+        //properties.put("child", identifier); @JsonIgnore
+
+        return Collections.singleton(TypeRepresentation.ofConcrete(identifier, properties));
+    }
+
+    public static TypeIdentifier expectedIdentifier() {
+        return TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass23;");
+    }
+
+}

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass24.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass24.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Sebastian Daschner, sebastian-daschner.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.sebastian_daschner.jaxrs_analyzer.analysis.results.testclasses.typeanalyzer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import com.sebastian_daschner.jaxrs_analyzer.model.Types;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import java.util.*;
+
+/**
+ * Test @JsonIgnoreType
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TestClass24 {
+
+    private int first;
+    private InnerTestClass child;
+
+    @JsonIgnoreType
+    private class InnerTestClass {
+        private int second;
+        private TestClass24 child;
+    }
+
+    public static Set<TypeRepresentation> expectedTypeRepresentations() {
+        final Map<String, TypeIdentifier> properties = new HashMap<>();
+
+        properties.put("first", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
+
+        final TypeIdentifier testClass24Identifier = expectedIdentifier();
+        final TypeRepresentation testClass24 = TypeRepresentation.ofConcrete(testClass24Identifier, properties);
+
+
+        return new HashSet<>(Arrays.asList(testClass24));
+    }
+
+    public static TypeIdentifier expectedIdentifier() {
+        return TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass24;");
+    }
+
+}

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass25.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass25.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 Sebastian Daschner, sebastian-daschner.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.sebastian_daschner.jaxrs_analyzer.analysis.results.testclasses.typeanalyzer;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils;
+import com.sebastian_daschner.jaxrs_analyzer.model.Types;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test @JsonIgnore at method level
+ */
+public class TestClass25 {
+
+    private static String PRIVATE_FIELD;
+    public static String PUBLIC_FIELD;
+    private String privateField;
+    protected String protectedField;
+
+    public String publicField;
+
+    @JsonIgnore
+    public String getTest() {
+        return null;
+    }
+
+    public int getInt() {
+        return 0;
+    }
+
+    public static String getStaticString() {
+        return null;
+    }
+
+    public String string() {
+        return null;
+    }
+
+    public static Set<TypeRepresentation> expectedTypeRepresentations() {
+        final Map<String, TypeIdentifier> properties = new HashMap<>();
+
+
+        properties.put("publicField", TypeUtils.STRING_IDENTIFIER);
+        properties.put("int", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
+
+        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+    }
+
+    public static TypeIdentifier expectedIdentifier() {
+        return TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass25;");
+    }
+
+}

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass26.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass26.java
@@ -1,0 +1,56 @@
+package com.sebastian_daschner.jaxrs_analyzer.analysis.results.testclasses.typeanalyzer;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @JsonIgnore in superclass
+ */
+public class TestClass26 extends SuperTestClass26 {
+
+    private String foobar;
+
+    public String getFoobar() {
+        return foobar;
+    }
+
+    public void setFoobar(String foobar) {
+        this.foobar = foobar;
+    }
+
+    public static Set<TypeRepresentation> expectedTypeRepresentations() {
+        final Map<String, TypeIdentifier> properties = new HashMap<>();
+
+        properties.put("foobar", TypeUtils.STRING_IDENTIFIER);
+
+        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+    }
+
+    public static TypeIdentifier expectedIdentifier() {
+        return TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass26;");
+    }
+
+}
+
+
+class SuperTestClass26 {
+
+    @JsonIgnore
+    private String test;
+
+    public String getTest() {
+        return test;
+    }
+
+    public void setTest(String test) {
+        this.test = test;
+    }
+
+}

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass27.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass27.java
@@ -1,0 +1,59 @@
+package com.sebastian_daschner.jaxrs_analyzer.analysis.results.testclasses.typeanalyzer;
+
+/**
+ * Created by rafael-pestano on 02/01/17.
+ */
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @JsonIgnoreType in superclass
+ */
+public class TestClass27 extends SuperTestClass27 {
+
+    private String foobar;
+
+    public String getFoobar() {
+        return foobar;
+    }
+
+    public void setFoobar(String foobar) {
+        this.foobar = foobar;
+    }
+
+    public static Set<TypeRepresentation> expectedTypeRepresentations() {
+        final Map<String, TypeIdentifier> properties = new HashMap<>();
+
+        properties.put("foobar", TypeUtils.STRING_IDENTIFIER);
+
+        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+    }
+
+    public static TypeIdentifier expectedIdentifier() {
+        return TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass27;");
+    }
+
+}
+
+@JsonIgnoreType
+class SuperTestClass27 {
+
+    private String test;
+
+    public String getTest() {
+        return test;
+    }
+
+    public void setTest(String test) {
+        this.test = test;
+    }
+
+}

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass28.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass28.java
@@ -1,0 +1,56 @@
+package com.sebastian_daschner.jaxrs_analyzer.analysis.results.testclasses.typeanalyzer;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @JsonIgnore in superclass method
+ */
+public class TestClass28 extends SuperTestClass28 {
+
+    private String foobar;
+
+    public String getFoobar() {
+        return foobar;
+    }
+
+    public void setFoobar(String foobar) {
+        this.foobar = foobar;
+    }
+
+    public static Set<TypeRepresentation> expectedTypeRepresentations() {
+        final Map<String, TypeIdentifier> properties = new HashMap<>();
+
+        properties.put("foobar", TypeUtils.STRING_IDENTIFIER);
+
+        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+    }
+
+    public static TypeIdentifier expectedIdentifier() {
+        return TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass28;");
+    }
+
+}
+
+
+class SuperTestClass28 {
+
+    private String test;
+
+    @JsonIgnore
+    public String getTest() {
+        return test;
+    }
+
+    public void setTest(String test) {
+        this.test = test;
+    }
+
+}


### PR DESCRIPTION
As discussed in #87, fields and types may now be hidden in representations via Jackson (2.x) annotations