### PR TITLE
Implement support for @deprecated annotations, fixing #96

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/classes/JAXRSAnnotatedSuperMethodVisitor.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/classes/JAXRSAnnotatedSuperMethodVisitor.java
@@ -57,6 +57,9 @@ class JAXRSAnnotatedSuperMethodVisitor extends MethodVisitor {
             case Types.OPTIONS:
                 methodResult.setHttpMethod(HttpMethod.OPTIONS);
                 break;
+            case Types.DEPRECATED:
+                methodResult.setDeprecated(true);
+                break;
             case Types.PATH:
                 return new PathAnnotationVisitor(methodResult);
             case Types.CONSUMES:

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/classes/JAXRSClassVisitor.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/classes/JAXRSClassVisitor.java
@@ -53,9 +53,11 @@ public class JAXRSClassVisitor extends ClassVisitor {
                 return new ConsumesAnnotationVisitor(classResult);
             case Types.PRODUCES:
                 return new ProducesAnnotationVisitor(classResult);
-            default:
-                return null;
+            case Types.DEPRECATED:
+                classResult.setDeprecated(true);
+                break;
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/classes/JAXRSMethodVisitor.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/classes/JAXRSMethodVisitor.java
@@ -60,6 +60,9 @@ class JAXRSMethodVisitor extends ProjectMethodVisitor {
             case Types.OPTIONS:
                 methodResult.setHttpMethod(HttpMethod.OPTIONS);
                 break;
+            case Types.DEPRECATED:
+                methodResult.setDeprecated(true);
+                break;
             case Types.PATH:
                 return new PathAnnotationVisitor(methodResult);
             case Types.CONSUMES:

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/ResultInterpreter.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/ResultInterpreter.java
@@ -29,11 +29,9 @@ import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.Doc;
 import com.sun.javadoc.MethodDoc;
 import com.sun.javadoc.ParamTag;
-import com.sun.javadoc.Tag;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static com.sebastian_daschner.jaxrs_analyzer.analysis.results.JavaDocParameterResolver.*;
 
@@ -140,16 +138,12 @@ public class ResultInterpreter {
     }
 
     private boolean hasMethodDeprecationTag(MethodDoc doc) {
-        return containsDeprecationTag(doc.tags());
+        return doc.tags(DEPRECATED_TAG_NAME).length > 0;
     }
 
     private boolean hasClassDeprecationTag(MethodDoc methodDoc) {
         final ClassDoc doc = methodDoc.containingClass();
-        return doc != null && containsDeprecationTag(doc.tags());
-    }
-
-    private boolean containsDeprecationTag(final Tag[] tags) {
-        return Stream.of(tags).anyMatch(tag -> DEPRECATED_TAG_NAME.equals(tag.name()));
+        return doc != null && doc.tags(DEPRECATED_TAG_NAME).length > 0;
     }
 
     private void addParameterDescriptions(final Set<MethodParameter> methodParameters, final MethodDoc methodDoc) {

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
@@ -30,6 +30,8 @@ public class AsciiDocBackend extends StringBackend {
         if (!StringUtils.isBlank(baseUri))
             builder.append(baseUri).append('/');
         builder.append(resource).append("`\n\n");
+        if (resourceMethod.isDeprecated())
+            builder.append("CAUTION: deprecated\n\n");
     }
 
     @Override

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackend.java
@@ -46,6 +46,8 @@ public class PlainTextBackend extends StringBackend {
         if (!StringUtils.isBlank(baseUri))
             builder.append(baseUri).append('/');
         builder.append(resource).append(":\n");
+        if (resourceMethod.isDeprecated())
+            builder.append(" Deprecated\n");
     }
 
     @Override

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
@@ -150,6 +150,9 @@ public class SwaggerBackend implements Backend {
         builder.add("consumes", consumes).add("produces", produces)
                 .add("parameters", buildParameters(method)).add("responses", buildResponses(method));
 
+        if (method.isDeprecated())
+            builder.add("deprecated", true);
+
         if (options.isRenderTags())
             Optional.ofNullable(extractTag(s)).ifPresent(t -> builder.add("tags", Json.createArrayBuilder().add(t)));
 

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/Types.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/Types.java
@@ -39,6 +39,8 @@ public final class Types {
     public static final String COOKIE_PARAM = "Ljavax/ws/rs/CookieParam;";
     public static final String MATRIX_PARAM = "Ljavax/ws/rs/MatrixParam;";
 
+    public static final String DEPRECATED = "Ljava/lang/Deprecated;";
+
     public static final String PRIMITIVE_VOID = "V";
     public static final String BOOLEAN = "Ljava/lang/Boolean;";
     public static final String PRIMITIVE_BOOLEAN = "Z";

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/ResourceMethod.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/ResourceMethod.java
@@ -34,6 +34,7 @@ public class ResourceMethod {
     private final HttpMethod method;
     private TypeIdentifier requestBody;
     private String requestBodyDescription;
+    private boolean deprecated;
 
     public ResourceMethod(final HttpMethod method, final String description) {
         Objects.requireNonNull(method);
@@ -69,6 +70,14 @@ public class ResourceMethod {
         return responses;
     }
 
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
     public String getDescription() {
         return description;
     }
@@ -93,6 +102,7 @@ public class ResourceMethod {
         if (!responses.equals(that.responses)) return false;
         if (!methodParameters.equals(that.methodParameters)) return false;
         if (method != that.method) return false;
+        if (deprecated != that.deprecated) return false;
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (requestBodyDescription != null ? !requestBodyDescription.equals(that.requestBodyDescription) : that.requestBodyDescription != null)
             return false;
@@ -106,6 +116,7 @@ public class ResourceMethod {
         result = 31 * result + responses.hashCode();
         result = 31 * result + methodParameters.hashCode();
         result = 31 * result + method.hashCode();
+        result = 31 * result + (deprecated ? 1231 : 1237);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (requestBodyDescription != null ? requestBodyDescription.hashCode() : 0);
         result = 31 * result + (requestBody != null ? requestBody.hashCode() : 0);

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/results/ClassResult.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/results/ClassResult.java
@@ -37,6 +37,7 @@ public class ClassResult {
     private final Set<String> requestMediaTypes = new HashSet<>();
     private final Set<String> responseMediaTypes = new HashSet<>();
     private MethodResult parentSubResourceLocator;
+    private boolean deprecated;
 
     public String getApplicationPath() {
         return applicationPath;
@@ -91,6 +92,14 @@ public class ClassResult {
         this.parentSubResourceLocator = parentSubResourceLocator;
     }
 
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -104,6 +113,7 @@ public class ClassResult {
         if (!classFields.equals(that.classFields)) return false;
         if (!methods.equals(that.methods)) return false;
         if (resourcePath != null ? !resourcePath.equals(that.resourcePath) : that.resourcePath != null) return false;
+        if (deprecated != that.deprecated) return false;
         return responseMediaTypes.equals(that.responseMediaTypes);
     }
 
@@ -115,6 +125,7 @@ public class ClassResult {
         result = 31 * result + methods.hashCode();
         result = 31 * result + requestMediaTypes.hashCode();
         result = 31 * result + responseMediaTypes.hashCode();
+        result = 31 * result + (deprecated ? 1231 : 1237);
         return result;
     }
 
@@ -128,6 +139,7 @@ public class ClassResult {
                 ", requestMediaTypes=" + requestMediaTypes +
                 ", responseMediaTypes=" + responseMediaTypes +
                 ", parentSubResourceLocator=" + (parentSubResourceLocator == null ? "null" : "notNull") +
+                ", deprecated=" + deprecated +
                 '}';
     }
 

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/results/MethodResult.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/results/MethodResult.java
@@ -47,6 +47,7 @@ public class MethodResult {
     private ClassResult subResource;
     private ClassResult parentResource;
     private MethodDoc methodDoc;
+    private boolean deprecated;
 
     public Set<String> getRequestMediaTypes() {
         return requestMediaTypes;
@@ -125,6 +126,14 @@ public class MethodResult {
         this.methodDoc = methodDoc;
     }
 
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -144,6 +153,7 @@ public class MethodResult {
         if (httpMethod != that.httpMethod) return false;
         if (subResource != null ? !subResource.equals(that.subResource) : that.subResource != null) return false;
         if (methodDoc != null ? !methodDoc.equals(that.methodDoc) : that.methodDoc != null) return false;
+        if (deprecated != that.deprecated) return false;
         return true;
     }
 
@@ -159,6 +169,7 @@ public class MethodResult {
         result = 31 * result + (httpMethod != null ? httpMethod.hashCode() : 0);
         result = 31 * result + (subResource != null ? subResource.hashCode() : 0);
         result = 31 * result + (methodDoc != null ? methodDoc.hashCode() : 0);
+        result = 31 * result + (deprecated ? 1231 : 1237);
         return result;
     }
 
@@ -176,6 +187,7 @@ public class MethodResult {
                 ", subResource=" + subResource +
                 ", methodDoc=" + methodDoc +
                 ", parentResource=" + (parentResource == null ? "null" : "notNull") +
+                ", deprecated=" + deprecated +
                 '}';
     }
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackendTest.java
@@ -248,7 +248,27 @@ public class AsciiDocBackendTest {
                         "*Content-Type*: `\\*/*`\n" +
                         "\n" +
                         "==== `200 OK`\n\n");
-        return data;
+        // deprecated method test
+        add(data, ResourcesBuilder.withBase("rest")
+            .andResource("res19", ResourceMethodBuilder.withMethod(HttpMethod.GET).andDeprecated(true)
+                .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
+            "= REST resources of project name\n" +
+                    "1.0\n" +
+                    "\n" +
+                    "== `GET rest/res19`\n" +
+                    "\n" +
+                    "CAUTION: deprecated\n" +
+                    "\n" +
+                    "=== Request\n" +
+                    "_No body_ + \n" +
+                    "\n" +
+                    "=== Response\n" +
+                    "*Content-Type*: `\\*/*`\n" +
+                    "\n" +
+                    "==== `200 OK`\n" +
+                    "*Header*: `Location` + \n" +
+                "*Response Body*: (`java.lang.String`) + \n\n");
+       return data;
     }
 
     public static void add(final Collection<Object[]> data, final Resources resources, final String output) {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackendTest.java
@@ -227,6 +227,22 @@ public class PlainTextBackendTest {
                         "  Content-Type: */*\n" +
                         "  Status Codes: 201\n" +
                         "   Header: Location\n\n\n");
+        add(data, ResourcesBuilder.withBase("rest")
+            .andResource("res19", ResourceMethodBuilder.withMethod(HttpMethod.GET).andDeprecated(true)
+                .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
+            "REST resources of project name:\n" +
+                    "1.0\n" +
+                    "\n" +
+                    "GET rest/res19:\n" +
+                    " Deprecated\n" +
+                    " Request:\n" +
+                    "  No body\n" +
+                    "\n" +
+                    " Response:\n" +
+                    "  Content-Type: */*\n" +
+                    "  Status Codes: 200\n" +
+                    "   Header: Location\n" +
+                    "   Response Body: java.lang.String\n\n\n");
         return data;
     }
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
@@ -234,6 +234,12 @@ public class SwaggerBackendTest {
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res18\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[{\"type\":\"string\",\"enum\":[\"APPLE\",\"BANANA\"],\"name\":\"q1\",\"in\":\"query\",\"required\":true},{\"type\":\"string\",\"enum\":[\"APPLE\",\"BANANA\"],\"name\":\"q2\",\"in\":\"query\",\"required\":true}],\"responses\":{}}}},\"definitions\":{}}"
         );
 
+        // deprecated method test
+        add(data, ResourcesBuilder.withBase("rest")
+            .andResource("res19", ResourceMethodBuilder.withMethod(HttpMethod.GET).andDeprecated(true)
+                .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
+            "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"\",\"basePath\":\"/project name/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res19\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{\"Location\":{\"type\":\"string\"}},\"schema\":{\"type\":\"string\"}}},\"deprecated\":true}}},\"definitions\":{}}",new HashMap<>());
+
         return data;
     }
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/builder/ClassResultBuilder.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/builder/ClassResultBuilder.java
@@ -128,6 +128,11 @@ public class ClassResultBuilder {
         return this;
     }
 
+    public ClassResultBuilder andDeprecated(final boolean deprecated) {
+        classResult.setDeprecated(deprecated);
+        return this;
+    }
+
     public ClassResult build() {
         return classResult;
     }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/builder/MethodResultBuilder.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/builder/MethodResultBuilder.java
@@ -143,6 +143,11 @@ public class MethodResultBuilder {
         return this;
     }
 
+    public MethodResultBuilder andDeprecated(final boolean deprecated) {
+        methodResult.setDeprecated(deprecated);
+        return this;
+    }
+
     public MethodResult build() {
         return methodResult;
     }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/builder/ResourceMethodBuilder.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/builder/ResourceMethodBuilder.java
@@ -150,6 +150,11 @@ public class ResourceMethodBuilder {
         return this;
     }
 
+    public ResourceMethodBuilder andDeprecated(final boolean deprecated) {
+        method.setDeprecated(deprecated);
+        return this;
+    }
+
     public ResourceMethod build() {
         return method;
     }


### PR DESCRIPTION
* parse `@Deprecated` annotation from bytecode and `@deprecated` from JavaDoc
* mark deprecated methods and methods of deprecated classes in all backends
* render deprecation in warnings for asciidoc and plaintext backends
* extend backend tests for deprecation

Here are example outputs (from the unit tests). While the swagger syntax is fixed the style of text and asciidoc is surely debatable:

**plaintext**
<pre>
= REST resources of project name
1.0

== `GET rest/res19`

CAUTION: deprecated

=== Request
_No body_ + 

=== Response
*Content-Type*: `\\*/*`

==== `200 OK`
*Header*: `Location` + 
*Response Body*: (`java.lang.String`) + 
</pre>

**asciidoc**
<pre>
REST resources of project name:
1.0

GET rest/res19:
 Deprecated
 Request:
  No body

 Response:
  Content-Type: */*
  Status Codes: 200
   Header: Location
   Response Body: java.lang.String
</pre>

**swagger.json**
<pre>{
  "swagger": "2.0",
  "info": {
    "version": "1.0",
    "title": "project name"
  },
  "host": "",
  "basePath": "/project name/rest",
  "schemes": [
    "http"
  ],
  "paths": {
    "/res19": {
      "get": {
        "consumes": [],
        "produces": [],
        "parameters": [],
        "responses": {
          "200": {
            "description": "OK",
            "headers": {
              "Location": {
                "type": "string"
              }
            },
            "schema": {
              "type": "string"
            }
          }
        },
        "deprecated": true
      }
    }
  },
  "definitions": {}
}</pre>
