### PR TITLE
replace fixed path separator by File.pathSeparator

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzer.java
@@ -7,6 +7,7 @@ import com.sebastian_daschner.jaxrs_analyzer.model.results.MethodResult;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.MethodDoc;
 
+import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,7 +61,7 @@ public class JavaDocAnalyzer {
     }
 
     private String joinPaths(final Set<Path> projectSourcePaths) {
-        return projectSourcePaths.stream().map(Path::toString).collect(Collectors.joining(":"));
+        return projectSourcePaths.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
     }
 
     private void combineResults(final Set<ClassResult> classResults) {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzerTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzerTest.java
@@ -61,7 +61,7 @@ public class ProjectAnalyzerTest {
 
         path = Paths.get(testClassPath).toAbsolutePath();
 
-        final Set<Path> classPaths = Stream.of(System.getProperty("java.class.path").split(":"))
+        final Set<Path> classPaths = Stream.of(System.getProperty("java.class.path").split(File.pathSeparator))
                 .map(Paths::get)
                 .collect(Collectors.toSet());
 


### PR DESCRIPTION
This fixes #100 Javadoc analysis fails on Windows