### PR TITLE
replace org.glassfish::javax.json snapshot with 1.1.0-M1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.0-M1</version>
         </dependency>
         <dependency>
             <groupId>javax</groupId>


### PR DESCRIPTION
org.glassfish::javax.json::1.1.0-M1 has been released on 27-Jan-2017

there seems to be no need for a SNAPSHOT dependency anymore.

