### PR TITLE
Allow for type erased return types since JavaDoc returns type erased return types

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/methods/MethodIdentifier.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/methods/MethodIdentifier.java
@@ -100,11 +100,13 @@ public class MethodIdentifier {
         if (parameters.equals(that.parameters))
             return true;
 
-        // fallback if signature matches after type erasure -> everything matches except signature
-        if (parameters.size() == that.parameters.size() && returnType.equals(that.returnType)) {
-            final List<String> types = parameters.stream().map(JavaUtils::toClassName).collect(Collectors.toList());
-            final List<String> thatTypes = that.parameters.stream().map(JavaUtils::toClassName).collect(Collectors.toList());
-            return types.equals(thatTypes);
+        // fallback if signature matches after type erasure
+        if (parameters.size() == that.parameters.size()) {
+            final List<String> erasedTypes = parameters.stream().map(JavaUtils::toClassName).collect(Collectors.toList());
+            final List<String> erasedThatTypes = that.parameters.stream().map(JavaUtils::toClassName).collect(Collectors.toList());
+            final String erasedReturnType = JavaUtils.toClassName(returnType);
+            final String erasedThatReturnType = JavaUtils.toClassName(that.returnType);
+            return erasedTypes.equals(erasedThatTypes) && erasedReturnType.equals(erasedThatReturnType);
         }
 
         return false;


### PR DESCRIPTION
Currently, JavaDoc cannot be acquired for:
```java
    /**
     * JavaDoc here.
     */
    Set<String> bob();
```
since the return type is type erased. This adds support for the return type to be type erased.

If possible, could you cut a release after merging please?