### PR TITLE
Fixed IndexOutOfBoundsException that occurs when @ApplicationPath is set to ""

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/PathNormalizer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/PathNormalizer.java
@@ -110,7 +110,7 @@ final class PathNormalizer {
         char current = 0;
         char last;
 
-        while (index < builder.length()) {
+        while ((index > -1) && (index < builder.length())) {
             last = current;
             current = builder.charAt(index);
 
@@ -130,13 +130,16 @@ final class PathNormalizer {
                     }
                     break;
             }
+
             if ((index == 0 || index == builder.length() - 1) && current == '/') {
                 builder.deleteCharAt(index);
-                if (index == builder.length())
+                if (index == builder.length()) {
                     // check again for path end
                     index--;
-            } else
+                }
+            } else {
                 index++;
+            }
         }
 
         return builder.toString();


### PR DESCRIPTION
Found and fixed an exception that happens when @ApplicationPath is set to "". This was probably also affecting the other Path-annotations, but they are rarely empty