### PR TITLE
support prettification of requests/responses

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/JAXRSAnalyzer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/JAXRSAnalyzer.java
@@ -29,6 +29,7 @@ public class JAXRSAnalyzer {
     private final String projectVersion;
     private final Path outputLocation;
     private final Backend backend;
+    private final boolean prettify;
 
     /**
      * Constructs a JAX-RS Analyzer.
@@ -42,7 +43,7 @@ public class JAXRSAnalyzer {
      * @param outputLocation     The location of the output file (output will be printed to standard out if {@code null})
      */
     public JAXRSAnalyzer(final Set<Path> projectClassPaths, final Set<Path> projectSourcePaths, final Set<Path> classPaths, final String projectName, final String projectVersion,
-                         final Backend backend, final Path outputLocation) {
+                         final Backend backend, final Path outputLocation, final Boolean prettify) {
         Objects.requireNonNull(projectClassPaths);
         Objects.requireNonNull(projectSourcePaths);
         Objects.requireNonNull(classPaths);
@@ -60,6 +61,7 @@ public class JAXRSAnalyzer {
         this.projectVersion = projectVersion;
         this.outputLocation = outputLocation;
         this.backend = backend;
+        this.prettify = prettify == null || prettify;
     }
 
     /**
@@ -74,7 +76,7 @@ public class JAXRSAnalyzer {
         }
 
         final Project project = new Project(projectName, projectVersion, resources);
-        final byte[] output = backend.render(project);
+        final byte[] output = backend.render(project, prettify);
 
         if (outputLocation != null) {
             outputToFile(output, outputLocation);

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/Main.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/Main.java
@@ -43,6 +43,7 @@ public class Main {
     private static String version = DEFAULT_VERSION;
     private static String backendType = "swagger";
     private static Path outputFileLocation;
+    private static boolean prettify;
 
     /**
      * Inspects JAX-RS projects and outputs the gathered information.
@@ -90,7 +91,7 @@ public class Main {
         final Backend backend = JAXRSAnalyzer.constructBackend(backendType);
         backend.configure(attributes);
 
-        final JAXRSAnalyzer jaxrsAnalyzer = new JAXRSAnalyzer(projectClassPaths, projectSourcePaths, classPaths, name, version, backend, outputFileLocation);
+        final JAXRSAnalyzer jaxrsAnalyzer = new JAXRSAnalyzer(projectClassPaths, projectSourcePaths, classPaths, name, version, backend, outputFileLocation, prettify);
         jaxrsAnalyzer.analyze();
     }
 
@@ -99,6 +100,12 @@ public class Main {
             for (int i = 0; i < args.length; i++) {
                 if (args[i].startsWith("-")) {
                     switch (args[i]) {
+                        case "-p":
+                            prettify = true;
+                            break;
+                        case "-np":
+                            prettify = false;
+                            break;
                         case "-b":
                             backendType = extractBackend(args[++i]);
                             break;

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/Backend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/Backend.java
@@ -31,9 +31,10 @@ public interface Backend {
      * Renders the REST resources of the given project.
      *
      * @param project The project to render including all information and resources
+     * @param prettify should the response be prettified if possible.
      * @return The data
      */
-    byte[] render(Project project);
+    byte[] render(Project project, boolean prettify);
 
     /**
      * Returns a human readable name of the actual backend.

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppender.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppender.java
@@ -34,7 +34,6 @@ class JsonRepresentationAppender implements TypeRepresentationVisitor {
     private final StringBuilder builder;
     private final Map<TypeIdentifier, TypeRepresentation> representations;
 
-    private int collectionDepth = 0;
     private Set<TypeIdentifier> visitedTypes = new HashSet<>();
 
     JsonRepresentationAppender(final StringBuilder builder, final Map<TypeIdentifier, TypeRepresentation> representations) {
@@ -64,17 +63,16 @@ class JsonRepresentationAppender implements TypeRepresentationVisitor {
             visitedTypes.remove(representation.getIdentifier());
             builder.deleteCharAt(builder.length() - 1).append('}');
         }
-
-        if (collectionDepth > 0) {
-            builder.append(new String(new char[collectionDepth]).replace('\0', ']'));
-            collectionDepth = 0;
-        }
     }
 
     @Override
-    public void visit(TypeRepresentation.CollectionTypeRepresentation representation) {
+    public void visitStart(TypeRepresentation.CollectionTypeRepresentation representation) {
         builder.append('[');
-        collectionDepth++;
+    }
+
+    @Override
+    public void visitEnd(TypeRepresentation.CollectionTypeRepresentation representation) {
+        builder.append(']');
     }
 
     @Override

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppender.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppender.java
@@ -79,11 +79,10 @@ class JsonRepresentationAppender implements TypeRepresentationVisitor {
 
     @Override
     public void visit(final TypeRepresentation.EnumTypeRepresentation representation) {
-        final String values = representation.getEnumValues().stream().sorted()
-                .map(s -> '"' + s + '"')
-                .collect(Collectors.joining("|"));
+        final String values = '"' + representation.getEnumValues().stream().sorted()
+                .collect(Collectors.joining("|")) + '"';
 
-        builder.append(values.isEmpty() ? "\"string\"" : values);
+        builder.append(values.length() == 2 ? "\"string\"" : values);
     }
 
     private static String toPrimitiveType(final TypeIdentifier value) {

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppender.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppender.java
@@ -1,16 +1,28 @@
 package com.sebastian_daschner.jaxrs_analyzer.backend;
 
-import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
-import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
-import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentationVisitor;
+import static com.sebastian_daschner.jaxrs_analyzer.backend.ComparatorUtils.mapKeyComparator;
+import static com.sebastian_daschner.jaxrs_analyzer.model.Types.BOOLEAN;
+import static com.sebastian_daschner.jaxrs_analyzer.model.Types.DOUBLE_TYPES;
+import static com.sebastian_daschner.jaxrs_analyzer.model.Types.INTEGER_TYPES;
+import static com.sebastian_daschner.jaxrs_analyzer.model.Types.PRIMITIVE_BOOLEAN;
+import static com.sebastian_daschner.jaxrs_analyzer.model.Types.STRING;
+import static java.util.Collections.singletonMap;
 
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.sebastian_daschner.jaxrs_analyzer.backend.ComparatorUtils.mapKeyComparator;
-import static com.sebastian_daschner.jaxrs_analyzer.model.Types.*;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+import javax.json.spi.JsonProvider;
+import javax.json.stream.JsonGenerator;
+
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentationVisitor;
 
 /**
  * Adds the JSON representation of type identifiers to String builders.
@@ -90,5 +102,4 @@ class JsonRepresentationAppender implements TypeRepresentationVisitor {
 
         return "{}";
     }
-
 }

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/StringBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/StringBackend.java
@@ -3,12 +3,25 @@ package com.sebastian_daschner.jaxrs_analyzer.backend;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.Project;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.ResourceMethod;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.Resources;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentationVisitor;
 
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static java.util.Collections.singletonMap;
 import static java.util.Comparator.comparing;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonStructure;
+import javax.json.JsonValue;
+import javax.json.JsonWriter;
+import javax.json.spi.JsonProvider;
+import javax.json.stream.JsonGenerator;
 
 /**
  * A backend that is backed by Strings (plain text).
@@ -22,22 +35,22 @@ public abstract class StringBackend implements Backend {
     protected Resources resources;
     protected String projectName;
     protected String projectVersion;
-    protected TypeRepresentationVisitor visitor;
+    protected boolean prettify;
 
-    private void initRender(final Project project) {
+    private void initRender(final Project project, final boolean prettify) {
         // initialize fields
         builder = new StringBuilder();
         resources = project.getResources();
         projectName = project.getName();
         projectVersion = project.getVersion();
-        visitor = new JsonRepresentationAppender(builder, resources.getTypeRepresentations());
+        this.prettify = prettify;
     }
 
     @Override
-    public byte[] render(final Project project) {
+    public byte[] render(final Project project, final boolean prettify) {
         lock.lock();
         try {
-            initRender(project);
+            initRender(project, prettify);
 
             final String output = renderInternal();
 
@@ -82,8 +95,36 @@ public abstract class StringBackend implements Backend {
     protected void appendResourceEnd() {
     }
 
+    protected String doVisit(final TypeRepresentation typeRepresentation) {
+        final StringBuilder builder = new StringBuilder();
+        final TypeRepresentationVisitor appender = new JsonRepresentationAppender(builder,
+                resources.getTypeRepresentations());
+        typeRepresentation.accept(appender);
+        final String json = builder.toString();
+        return prettify ? format(json) : json;
+    }
+
     private static byte[] serialize(final String output) {
         return output.getBytes();
     }
 
+    private String format(final String json) {
+        final JsonProvider provider = JsonProvider.provider();
+        final StringWriter out = new StringWriter();
+        try (final JsonReader reader = provider.createReader(new StringReader(json));
+             final JsonWriter jsonWriter = provider.createWriterFactory(singletonMap(JsonGenerator.PRETTY_PRINTING, true))
+                                                   .createWriter(out)) {
+
+            // jsonWriter.write(reader.readValue()); // bug in RI, can switch to johnzon
+            final JsonStructure read = reader.read();
+            if (read.getValueType() == JsonValue.ValueType.OBJECT) {
+                jsonWriter.writeObject(JsonObject.class.cast(read));
+            } else if (read.getValueType() == JsonValue.ValueType.ARRAY) {
+                jsonWriter.writeArray(JsonArray.class.cast(read));
+            } else { // no reformatting
+                return json;
+            }
+            return out.toString().trim();
+        }
+    }
 }

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
@@ -43,12 +43,12 @@ public class AsciiDocBackend extends StringBackend {
             builder.append(resourceMethod.getRequestMediaTypes().isEmpty() ? TYPE_WILDCARD : toString(resourceMethod.getRequestMediaTypes()));
             builder.append("` + \n");
 
-            builder.append("*Request Body*: (").append(toTypeOrCollection(resourceMethod.getRequestBody())).append(") + \n");
-            Optional.ofNullable(resources.getTypeRepresentations().get(resourceMethod.getRequestBody())).ifPresent(r -> {
-                builder.append('`');
-                builder.append(doVisit(r));
-                builder.append("` + \n");
-            });
+            builder.append("*Request Body*: (").append(toTypeOrCollection(resourceMethod.getRequestBody())).append(")");
+            Optional.ofNullable(resources.getTypeRepresentations().get(resourceMethod.getRequestBody())).ifPresent(
+                    this::generateSample);
+            if (prettify) {
+                builder.append("\n");
+            }
         } else {
             builder.append("_No body_ + \n");
         }
@@ -93,16 +93,28 @@ public class AsciiDocBackend extends StringBackend {
             response.getHeaders().forEach(h -> builder.append("*Header*: `").append(h).append("` + \n"));
 
             if (response.getResponseBody() != null) {
-                builder.append("*Response Body*: ").append('(').append(toTypeOrCollection(response.getResponseBody())).append(") + \n");
-                Optional.ofNullable(resources.getTypeRepresentations().get(response.getResponseBody())).ifPresent(r -> {
-                    builder.append('`');
-                    builder.append(doVisit(r));
-                    builder.append("` + \n");
-                });
+                builder.append("*Response Body*: ").append('(').append(toTypeOrCollection(response.getResponseBody())).append(")");
+                Optional.ofNullable(resources.getTypeRepresentations().get(response.getResponseBody())).ifPresent(
+                        this::generateSample);
+                builder.append("\n");
             }
 
             builder.append('\n');
         });
+    }
+
+    private void generateSample(TypeRepresentation r) {
+        if (!prettify) {
+            builder.append(" + \n`");
+        } else {
+            builder.append("\n\n[source,javascript]\n----\n");
+        }
+        builder.append(doVisit(r));
+        if (!prettify) {
+            builder.append("` + \n");
+        } else {
+            builder.append("\n----\n\n");
+        }
     }
 
     private String toTypeOrCollection(final TypeIdentifier type) {

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackend.java
@@ -46,7 +46,7 @@ public class AsciiDocBackend extends StringBackend {
             builder.append("*Request Body*: (").append(toTypeOrCollection(resourceMethod.getRequestBody())).append(") + \n");
             Optional.ofNullable(resources.getTypeRepresentations().get(resourceMethod.getRequestBody())).ifPresent(r -> {
                 builder.append('`');
-                r.accept(visitor);
+                builder.append(doVisit(r));
                 builder.append("` + \n");
             });
         } else {
@@ -96,7 +96,7 @@ public class AsciiDocBackend extends StringBackend {
                 builder.append("*Response Body*: ").append('(').append(toTypeOrCollection(response.getResponseBody())).append(") + \n");
                 Optional.ofNullable(resources.getTypeRepresentations().get(response.getResponseBody())).ifPresent(r -> {
                     builder.append('`');
-                    r.accept(visitor);
+                    builder.append(doVisit(r));
                     builder.append("` + \n");
                 });
             }

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackend.java
@@ -62,7 +62,7 @@ public class PlainTextBackend extends StringBackend {
             builder.append("  Request Body: ").append(toTypeOrCollection(resourceMethod.getRequestBody())).append('\n');
             Optional.ofNullable(resources.getTypeRepresentations().get(resourceMethod.getRequestBody())).ifPresent(r -> {
                 builder.append("   ");
-                r.accept(visitor);
+                builder.append(doVisit(r));
                 builder.append('\n');
             });
         } else {
@@ -111,7 +111,7 @@ public class PlainTextBackend extends StringBackend {
                 builder.append("   Response Body: ").append(toTypeOrCollection(response.getResponseBody())).append('\n');
                 Optional.ofNullable(resources.getTypeRepresentations().get(response.getResponseBody())).ifPresent(r -> {
                     builder.append("    ");
-                    r.accept(visitor);
+                    builder.append(doVisit(r));
                     builder.append('\n');
                 });
             }

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SchemaBuilder.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SchemaBuilder.java
@@ -89,7 +89,13 @@ class SchemaBuilder {
             }
 
             @Override
-            public void visit(final TypeRepresentation.CollectionTypeRepresentation representation) {
+            public void visitStart(final TypeRepresentation.CollectionTypeRepresentation representation) {
+                builder.add("type", "array");
+                inCollection = true;
+            }
+
+            @Override
+            public void visitEnd(final TypeRepresentation.CollectionTypeRepresentation representation) {
                 builder.add("type", "array");
                 inCollection = true;
             }

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackend.java
@@ -62,7 +62,7 @@ public class SwaggerBackend implements Backend {
     }
 
     @Override
-    public byte[] render(final Project project) {
+    public byte[] render(final Project project, final boolean prettify) {
         lock.lock();
         try {
             // initialize fields

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/TypeRepresentation.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/TypeRepresentation.java
@@ -169,8 +169,9 @@ public abstract class TypeRepresentation {
 
         @Override
         public void accept(final TypeRepresentationVisitor visitor) {
-            visitor.visit(this);
+            visitor.visitStart(this);
             representation.accept(visitor);
+            visitor.visitEnd(this);
         }
 
         /**

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/TypeRepresentationVisitor.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/TypeRepresentationVisitor.java
@@ -9,7 +9,8 @@ public interface TypeRepresentationVisitor {
 
     void visit(TypeRepresentation.ConcreteTypeRepresentation representation);
 
-    void visit(TypeRepresentation.CollectionTypeRepresentation representation);
+    void visitStart(TypeRepresentation.CollectionTypeRepresentation representation);
+    void visitEnd(TypeRepresentation.CollectionTypeRepresentation representation);
 
     void visit(TypeRepresentation.EnumTypeRepresentation representation);
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/project/classes/testclasses/TestClass6.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/project/classes/testclasses/TestClass6.java
@@ -17,6 +17,7 @@
 package com.sebastian_daschner.jaxrs_analyzer.analysis.project.classes.testclasses;
 
 import com.sebastian_daschner.jaxrs_analyzer.builder.ClassResultBuilder;
+import com.sebastian_daschner.jaxrs_analyzer.builder.HttpResponseBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.builder.MethodResultBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.model.Types;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.HttpMethod;
@@ -34,8 +35,8 @@ public interface TestClass6 {
     Model getInfo(final String info);
 
     static ClassResult getResult() {
-        final MethodResult method = MethodResultBuilder.withResponses()//HttpResponseBuilder.newBuilder()
-//                .andEntityTypes("com.sebastian_daschner.jaxrs_analyzer.analysis.project.classes.testclasses.TestClass6$Model").build())
+        final MethodResult method = MethodResultBuilder.withResponses(HttpResponseBuilder.newBuilder()
+                .andEntityTypes("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/project/classes/testclasses/TestClass6$Model;").build())
                 .andPath("{info}").andMethod(HttpMethod.GET).andRequestBodyType(Types.STRING).build();
         return ClassResultBuilder.withResourcePath("test").andMethods(method).build();
     }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppenderTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppenderTest.java
@@ -45,7 +45,7 @@ public class JsonRepresentationAppenderTest {
     @Test
     public void testEnum() {
         TypeRepresentation.ofEnum(STRING_IDENTIFIER, "Foo", "bar").accept(cut);
-        assertThat(builder.toString(), is("\"Foo\"|\"bar\""));
+        assertThat(builder.toString(), is("\"Foo|bar\""));
     }
 
     @Test
@@ -120,7 +120,7 @@ public class JsonRepresentationAppenderTest {
         representations.put(identifier, representation);
         representations.put(enumIdentifier, enumRepresentation);
         representation.accept(cut);
-        assertThat(builder.toString(), is("{\"abc\":\"string\",\"enumeration\":\"BAR\"|\"BAZ\"|\"FOO\",\"hello\":\"string\",\"world\":0}"));
+        assertThat(builder.toString(), is("{\"abc\":\"string\",\"enumeration\":\"BAR|BAZ|FOO\",\"hello\":\"string\",\"world\":0}"));
     }
 
     @Test

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackendTest.java
@@ -75,7 +75,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Header*: `Location` + \n" +
-                        "*Response Body*: (`java.lang.String`) + \n\n", false);
+                        "*Response Body*: (`java.lang.String`)\n\n", false);
 
         add(data, getRestRes1String,
                 "= REST resources of project name\n" +
@@ -91,7 +91,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Header*: `Location` + \n" +
-                        "*Response Body*: (`java.lang.String`) + \n\n", true);
+                        "*Response Body*: (`java.lang.String`)\n\n", true);
 
         identifier = TypeIdentifier.ofDynamic();
         properties.put("key", stringIdentifier);
@@ -120,7 +120,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Response Body*: (`javax.json.Json`) + \n" +
-                        "`{\"another\":0,\"key\":\"string\"}` + \n\n", false);
+                        "`{\"another\":0,\"key\":\"string\"}` + \n\n\n", false);
         add(data, getRestRes1Json,
                 "= REST resources of project name\n" +
                         "1.0\n" +
@@ -133,9 +133,7 @@ public class AsciiDocBackendTest {
                         "=== Response\n" +
                         "*Content-Type*: `\\*/*`\n" +
                         "\n" +
-                        "==== `200 OK`\n" +
-                        "*Response Body*: (`javax.json.Json`) + \n" +
-                        "`{\n" + "    \"another\":0,\n" + "    \"key\":\"string\"\n" + "}` + \n\n", true);
+                        "==== `200 OK`\n" + "*Response Body*: (`javax.json.Json`)\n\n[source,javascript]\n" + "----\n" + "{\n" + "    \"another\":0,\n" + "    \"key\":\"string\"\n" + "}\n" + "----\n\n\n\n", true);
 
         identifier = TypeIdentifier.ofDynamic();
         properties = new HashMap<>();
@@ -158,7 +156,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Response Body*: (`javax.json.Json`) + \n" +
-                        "`[{\"another\":0,\"key\":\"string\"}]` + \n\n", false);
+                        "`[{\"another\":0,\"key\":\"string\"}]` + \n\n\n", false);
 
         identifier = TypeIdentifier.ofDynamic();
         add(data, ResourcesBuilder.withBase("rest")
@@ -178,7 +176,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Response Body*: (`javax.json.Json`) + \n" +
-                        "`[\"string\"]` + \n\n", false);
+                        "`[\"string\"]` + \n\n\n", false);
 
         identifier = TypeIdentifier.ofDynamic();
         properties = new HashMap<>();
@@ -200,7 +198,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Response Body*: (`javax.json.Json`) + \n" +
-                        "`[{\"key\":\"string\"}]` + \n\n", false);
+                        "`[{\"key\":\"string\"}]` + \n\n\n", false);
 
         properties = new HashMap<>();
         properties.put("name", stringIdentifier);
@@ -222,7 +220,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Response Body*: (`com.sebastian_daschner.test.Model`) + \n" +
-                        "`{\"name\":\"string\",\"value\":0}` + \n\n", false);
+                        "`{\"name\":\"string\",\"value\":0}` + \n\n\n", false);
 
         identifier = TypeIdentifier.ofType("Ljava/util/List<Lcom/sebastian_daschner/test/Model;>;");
         properties = new HashMap<>();
@@ -245,7 +243,7 @@ public class AsciiDocBackendTest {
                         "\n" +
                         "==== `200 OK`\n" +
                         "*Response Body*: (Collection of `com.sebastian_daschner.test.Model`) + \n" +
-                        "`[{\"name\":\"string\",\"value\":0}]` + \n\n", false);
+                        "`[{\"name\":\"string\",\"value\":0}]` + \n\n\n", false);
 
         add(data, ResourcesBuilder.withBase("rest")
                         .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
@@ -317,7 +315,7 @@ public class AsciiDocBackendTest {
                     "\n" +
                     "==== `200 OK`\n" +
                     "*Header*: `Location` + \n" +
-                "*Response Body*: (`java.lang.String`) + \n\n", false);
+                "*Response Body*: (`java.lang.String`)\n\n", false);
        return data;
     }
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackendTest.java
@@ -34,7 +34,7 @@ public class PlainTextBackendTest {
     @Test
     public void test() {
         final Project project = new Project("project name", "1.0", resources);
-        final String actualOutput = new String(cut.render(project));
+        final String actualOutput = new String(cut.render(project, false));
         assertEquals(expectedOutput, actualOutput);
     }
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
@@ -55,7 +55,7 @@ public class SwaggerBackendTest {
     @Test
     public void test() {
         final Project project = new Project("project name", "1.0", resources);
-        final String actualOutput = new String(cut.render(project));
+        final String actualOutput = new String(cut.render(project, false));
 
         // TODO to fix test w/ different formattings
 //            assertEquals(expectedOutput, actualOutput);


### PR DESCRIPTION
Idea is to add a flag to prettify the payloads for string based backends (adoc and plain)

linked to issue: https://github.com/sdaschner/jaxrs-analyzer/issues/125

Side note: made a few changes compared to 0.15 (I think they are ok but just want to mention them):

1. enum get merged into a string instead of something not json ("foo"|"bar" would be "foo|bar")
2. replaced visit(collection) by visitStart/visitEnd(collection) to be able to ensure the [ and ] are symmetric (was not the case)
3. changed a bit the adoc output (added some \n) to ensure it renders properly in html even with prettification (so you can get few more empty lines which are not affecting the rendering normally)