### PR TITLE
Swagger backend now separates multiple dynamic type instances

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SchemaBuilder.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SchemaBuilder.java
@@ -168,8 +168,14 @@ class SchemaBuilder {
     }
 
     private String buildDefinition(final String typeName) {
-        final String definition = typeName.startsWith(TypeIdentifier.DYNAMIC_TYPE_PREFIX) ? "JsonObject" :
-                typeName.substring(typeName.lastIndexOf('/') + 1, typeName.length() - 1);
+
+        String definition;
+        if (typeName.startsWith(TypeIdentifier.DYNAMIC_TYPE_PREFIX)) {
+            String id = typeName.substring(TypeIdentifier.DYNAMIC_TYPE_PREFIX.length());
+            definition = "JsonObject" + ("1".equals(id) ? "" : "_" + id);
+        } else {
+            definition = typeName.substring(typeName.lastIndexOf('/') + 1, typeName.length() - 1);
+        }
 
         final Pair<String, JsonObject> containedEntry = jsonDefinitions.get(definition);
         if (containedEntry == null || containedEntry.getLeft() != null && containedEntry.getLeft().equals(typeName))

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/TypeIdentifier.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/TypeIdentifier.java
@@ -31,6 +31,10 @@ public abstract class TypeIdentifier {
         return new DynamicTypeIdentifier(dynamicCounter.incrementAndGet());
     }
 
+    public static void resetDynamicCounter() {
+        dynamicCounter.set(0);
+    }
+
     private static class JavaTypeIdentifier extends TypeIdentifier {
         private final String type;
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/project/classes/testclasses/TestClass2.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/project/classes/testclasses/TestClass2.java
@@ -49,7 +49,7 @@ public class TestClass2 {
 
     public static ClassResult getResult() {
 
-        final MethodResult firstMethod = MethodResultBuilder.withResponses(HttpResponseBuilder.newBuilder().andEntityTypes(Types.PRIMITIVE_INT).build())
+        final MethodResult firstMethod = MethodResultBuilder.withResponses(HttpResponseBuilder.newBuilder().andEntityTypes(Types.PRIMITIVE_INT).andContentTypes("text/html").build())
                 .andResponseMediaTypes("text/html").andMethod(HttpMethod.GET).build();
         final MethodResult secondMethod = MethodResultBuilder.withResponses(HttpResponseBuilder.withStatues(202).build())
                 .andMethod(HttpMethod.POST).andRequestBodyType(Types.STRING).build();

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
@@ -96,6 +96,7 @@ public class SwaggerBackendTest {
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"https\",\"wss\"],\"paths\":{\"/res1\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{\"Location\":{\"type\":\"string\"}},\"schema\":{\"type\":\"string\"}}}}}},\"definitions\":{}}",
                 options);
 
+        TypeIdentifier.resetDynamicCounter();
         identifier = TypeIdentifier.ofDynamic();
         properties.put("key", stringIdentifier);
         properties.put("another", intIdentifier);
@@ -104,6 +105,7 @@ public class SwaggerBackendTest {
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res2\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"$ref\":\"#/definitions/JsonObject\"}}}}}},\"definitions\":{\"JsonObject\":{\"properties\":{\"another\":{\"type\":\"integer\"},\"key\":{\"type\":\"string\"}}}}}");
 
+        TypeIdentifier.resetDynamicCounter();
         identifier = TypeIdentifier.ofDynamic();
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);
@@ -112,8 +114,9 @@ public class SwaggerBackendTest {
                         .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
                         .andResource("res3", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
-                "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res3\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/JsonObject\"}}}}}}},\"definitions\":{\"JsonObject\":{\"properties\":{\"another\":{\"type\":\"integer\"},\"key\":{\"type\":\"string\"}}}}}");
+                "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res3\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/JsonObject_2\"}}}}}}},\"definitions\":{\"JsonObject_2\":{\"properties\":{\"another\":{\"type\":\"integer\"},\"key\":{\"type\":\"string\"}}}}}");
 
+        TypeIdentifier.resetDynamicCounter();
         identifier = TypeIdentifier.ofDynamic();
         add(data, ResourcesBuilder.withBase("rest")
                         .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(stringIdentifier)))
@@ -121,6 +124,7 @@ public class SwaggerBackendTest {
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res4\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}}}},\"definitions\":{}}");
 
+        TypeIdentifier.resetDynamicCounter();
         identifier = TypeIdentifier.ofDynamic();
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);


### PR DESCRIPTION
This is a fix for issue #147 .
The fix contains code to generate separate dynamic Json types in the swagger backend so that e.g. responses generated with the javax.json builders will give correct results.
There is also a test for the issue.
Some other tests needed small changes because they actually relied on the erratic behavior.
I also had to introduce a `resetDynamicCounter()` method in the TypeIdentifier class in order to test because it uses a static variable for counting which is not otherwise accessible.