### PR TITLE
Replace obsolete gradle plugin link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ For usage see the https://github.com/sdaschner/jaxrs-analyzer/blob/master/Docume
 The Analyzer can be added to your project via https://github.com/sdaschner/jaxrs-analyzer-maven-plugin[Maven plugin].
 
 == Gradle Plugin
-For `Gradle` based projects - third-party https://github.com/eshepelyuk/gradle-jaxrs-analyzer-plugin[Gradle plugin] could be used.
+For `Gradle` based projects - third-party https://github.com/grimmjo/jaxrs-analyzer-gradle-plugin[Gradle plugin] could be used.
 
 == Standalone
 Instead of using the Maven plugin, the tool can also run directly from the jar file.


### PR DESCRIPTION
The gradle plugin link is not working anymore. The new link refers to a plugin I've created.