### PR TITLE
Fix for "analyze-jaxrs failed. ConcurrentModificationException #170"

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzer.java
@@ -75,7 +75,7 @@ public class JavaDocAnalyzer {
     }
 
     private MethodResult findMethodResult(final MethodIdentifier identifier, final ClassResult classResult) {
-        if (classResult.getOriginalClass().equals(identifier.getContainingClass()))
+        if (classResult.getOriginalClass()!=null && classResult.getOriginalClass().equals(identifier.getContainingClass()))
             return classResult.getMethods().stream()
                     .filter(methodResult -> equalsSimpleTypeNames(identifier, methodResult))
                     .findAny().orElse(null);

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/elements/Element.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/elements/Element.java
@@ -61,8 +61,12 @@ public class Element {
      * @return This element (needed as BinaryOperator)
      */
     public Element merge(final Element element) {
-        types.addAll(element.types);
-        possibleValues.addAll(element.possibleValues);
+        if(types != element.types) {
+            types.addAll(element.types);
+        }
+        if(possibleValues != element.possibleValues) {
+            possibleValues.addAll(element.possibleValues);
+        }
         return this;
     }
 


### PR DESCRIPTION
We have an endpoint in our project where we are returning different response codes based on condition and this plugin gives ConcurrentModificationException from merge element.

This is a quick fix to handle the ConcurrentModificationException