### PR TITLE
Ensure that superclass JAX-RS annotations are scanned

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzer.java
@@ -123,6 +123,11 @@ public class ProjectAnalyzer {
             final ClassVisitor visitor = new JAXRSClassVisitor(classResult);
 
             classReader.accept(visitor, ClassReader.EXPAND_FRAMES);
+
+            // recursively visit any super classes
+            if (!classReader.getSuperName().equals("java/lang/Object")) {
+                analyzeClass(classReader.getSuperName(), classResult);
+            }
         } catch (IOException e) {
             LogProvider.error("The class " + className + " could not be loaded!");
             LogProvider.debug(e);


### PR DESCRIPTION
Fix issue https://github.com/sdaschner/jaxrs-analyzer/issues/140 (superclass JAX-RS annotations being ignored), caused by ASM not looking at superclasses by default.

This change adapts `ProjectAnalyzer` so that the superclass of a method is also visited, with the ASM results being added to `ClassResult` as normal.

This then required some tweaks to `JavaDocAnalyzer` because the `classResult.getOriginalClass().equals(identifier.getContainingClass())` part wasn't working as you'd expect.