### PR TITLE
Reflect model/POJO JavaDocs through to Swagger 'description' fields

### DIFF
--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzer.java
@@ -21,6 +21,7 @@ import com.sebastian_daschner.jaxrs_analyzer.analysis.bytecode.BytecodeAnalyzer;
 import com.sebastian_daschner.jaxrs_analyzer.analysis.classes.ContextClassReader;
 import com.sebastian_daschner.jaxrs_analyzer.analysis.classes.JAXRSClassVisitor;
 import com.sebastian_daschner.jaxrs_analyzer.analysis.javadoc.JavaDocAnalyzer;
+import com.sebastian_daschner.jaxrs_analyzer.analysis.javadoc.JavaDocAnalyzerResults;
 import com.sebastian_daschner.jaxrs_analyzer.analysis.results.ResultInterpreter;
 import com.sebastian_daschner.jaxrs_analyzer.model.JavaUtils;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.Resources;
@@ -104,9 +105,9 @@ public class ProjectAnalyzer {
                 bytecodeAnalyzer.analyzeBytecode(classResult);
             }
 
-            javaDocAnalyzer.analyze(projectSourcePaths, classResults);
+            final JavaDocAnalyzerResults javaDocAnalyzerResults = javaDocAnalyzer.analyze(projectSourcePaths, classResults);
 
-            return resultInterpreter.interpret(classResults);
+            return resultInterpreter.interpret(javaDocAnalyzerResults);
         } finally {
             lock.unlock();
         }

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzer.java
@@ -17,7 +17,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -26,10 +31,12 @@ import java.util.stream.Stream;
 public class JavaDocAnalyzer {
 
     private final Map<MethodIdentifier, MethodComment> methodComments = new HashMap<>();
+    private final JavaDocParserVisitor javaDocParserVisitor = new JavaDocParserVisitor(methodComments);
 
-    public void analyze(final Set<Path> projectSourcePaths, final Set<ClassResult> classResults) {
+    public JavaDocAnalyzerResults analyze(final Set<Path> projectSourcePaths, final Set<ClassResult> classResults) {
         invokeParser(projectSourcePaths);
         combineResults(classResults);
+        return new JavaDocAnalyzerResults(classResults, javaDocParserVisitor.getClassComments());
     }
 
     private void invokeParser(Set<Path> projectSourcePaths) {
@@ -55,7 +62,7 @@ public class JavaDocAnalyzer {
             }
         });
 
-        files.forEach(path -> parseJavaDoc(path, new JavaDocParserVisitor(methodComments)));
+        files.forEach(path -> parseJavaDoc(path, javaDocParserVisitor));
     }
 
     private static void parseJavaDoc(Path path, JavaDocParserVisitor visitor) {

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzerResults.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/javadoc/JavaDocAnalyzerResults.java
@@ -1,0 +1,37 @@
+package com.sebastian_daschner.jaxrs_analyzer.analysis.javadoc;
+
+import com.sebastian_daschner.jaxrs_analyzer.model.javadoc.ClassComment;
+import com.sebastian_daschner.jaxrs_analyzer.model.results.ClassResult;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Tristan Perry
+ */
+public class JavaDocAnalyzerResults {
+
+    /**
+     * Contains a range of class-level data, including the JAX-RS 'endpoint' methods which will be invoked when endpoints are hit.
+     */
+    private final Set<ClassResult> classResults;
+
+    /**
+     * Contains JavaDoc comments/messages for classes and their fields.
+     */
+    private final Map<String, ClassComment> classComments;
+
+    public JavaDocAnalyzerResults(Set<ClassResult> classResults, Map<String, ClassComment> classComments) {
+        this.classResults = classResults;
+        this.classComments = classComments;
+    }
+
+    public Set<ClassResult> getClassResults() {
+        return classResults;
+    }
+
+    public Map<String, ClassComment> getClassComments() {
+        return classComments;
+    }
+
+}

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/DynamicTypeAnalyzer.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/DynamicTypeAnalyzer.java
@@ -75,7 +75,7 @@ class DynamicTypeAnalyzer {
 
     private TypeIdentifier analyzeInternal(final JsonArray jsonArray) {
         final TypeIdentifier containedIdentifier = jsonArray.isEmpty() ? TypeIdentifier.ofType(Types.OBJECT) : analyzeInternal(jsonArray.get(0));
-        final TypeRepresentation containedRepresentation = typeRepresentations.getOrDefault(containedIdentifier, TypeRepresentation.ofConcrete(containedIdentifier));
+        final TypeRepresentation containedRepresentation = typeRepresentations.getOrDefault(containedIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(containedIdentifier).build());
 
         final TypeIdentifier existingCollection = findExistingCollection(containedRepresentation);
         if (existingCollection != null) {
@@ -96,7 +96,7 @@ class DynamicTypeAnalyzer {
             return existing;
 
         final TypeIdentifier identifier = TypeIdentifier.ofDynamic();
-        typeRepresentations.put(identifier, TypeRepresentation.ofConcrete(identifier, properties));
+        typeRepresentations.put(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build());
         return identifier;
     }
 

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/ResultInterpreter.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/ResultInterpreter.java
@@ -16,6 +16,7 @@
 
 package com.sebastian_daschner.jaxrs_analyzer.analysis.results;
 
+import com.sebastian_daschner.jaxrs_analyzer.analysis.javadoc.JavaDocAnalyzerResults;
 import com.sebastian_daschner.jaxrs_analyzer.model.JavaUtils;
 import com.sebastian_daschner.jaxrs_analyzer.model.elements.HttpResponse;
 import com.sebastian_daschner.jaxrs_analyzer.model.javadoc.ClassComment;
@@ -51,15 +52,15 @@ public class ResultInterpreter {
      *
      * @return All REST resources
      */
-    public Resources interpret(final Set<ClassResult> classResults) {
+    public Resources interpret(final JavaDocAnalyzerResults javaDocAnalyzerResults) {
         resources = new Resources();
-        resources.setBasePath(PathNormalizer.getApplicationPath(classResults));
+        resources.setBasePath(PathNormalizer.getApplicationPath(javaDocAnalyzerResults.getClassResults()));
 
-        javaTypeAnalyzer = new JavaTypeAnalyzer(resources.getTypeRepresentations());
+        javaTypeAnalyzer = new JavaTypeAnalyzer(resources.getTypeRepresentations(), javaDocAnalyzerResults.getClassComments());
         dynamicTypeAnalyzer = new DynamicTypeAnalyzer(resources.getTypeRepresentations());
         stringParameterResolver = new StringParameterResolver(resources.getTypeRepresentations(), javaTypeAnalyzer);
 
-        classResults.stream().filter(c -> c.getResourcePath() != null).forEach(this::interpretClassResult);
+        javaDocAnalyzerResults.getClassResults().stream().filter(c -> c.getResourcePath() != null).forEach(this::interpretClassResult);
         resources.consolidateMultiplePaths();
 
         return resources;

--- a/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/javadoc/MemberParameterTag.java
+++ b/src/main/java/com/sebastian_daschner/jaxrs_analyzer/model/javadoc/MemberParameterTag.java
@@ -12,6 +12,7 @@ import java.util.Map;
  */
 public class MemberParameterTag {
 
+    private final String name;
     private final String comment;
 
     /**
@@ -19,9 +20,14 @@ public class MemberParameterTag {
      */
     private final Map<String, String> annotations;
 
-    public MemberParameterTag(String comment, Map<String, String> annotations) {
+    public MemberParameterTag(String name, String comment, Map<String, String> annotations) {
+        this.name = name;
         this.comment = comment;
         this.annotations = Collections.unmodifiableMap(annotations);
+    }
+
+    public String getName() {
+        return name;
     }
 
     public String getComment() {
@@ -30,6 +36,11 @@ public class MemberParameterTag {
 
     public Map<String, String> getAnnotations() {
         return annotations;
+    }
+
+    @Override
+    public String toString() {
+        return "MemberParameterTag{" + "name='" + name + '\'' + ", comment='" + comment + '\'' + ", annotations=" + annotations + '}';
     }
 
 }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzerTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/ProjectAnalyzerTest.java
@@ -16,29 +16,44 @@
 
 package com.sebastian_daschner.jaxrs_analyzer.analysis;
 
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.sebastian_daschner.jaxrs_analyzer.LogProvider;
 import com.sebastian_daschner.jaxrs_analyzer.builder.ResourceMethodBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.builder.ResponseBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.model.Types;
-import com.sebastian_daschner.jaxrs_analyzer.model.rest.*;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.HttpMethod;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.ResourceMethod;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.Resources;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.Response;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
-import java.io.File;
-import java.net.MalformedURLException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
-import static org.junit.Assert.*;
 
 public class ProjectAnalyzerTest {
 
@@ -158,13 +173,14 @@ public class ProjectAnalyzerTest {
         properties.put("id", TypeIdentifier.ofType(Types.PRIMITIVE_LONG));
         properties.put("name", stringIdentifier);
         final TypeIdentifier modelIdentifier = TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_test/Model;");
-        final TypeRepresentation modelRepresentation = TypeRepresentation.ofConcrete(modelIdentifier, properties);
+        final TypeRepresentation modelRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(modelIdentifier).properties(properties).build();
         resources.getTypeRepresentations().put(modelIdentifier, modelRepresentation);
 
         final TypeIdentifier modelListIdentifier = TypeIdentifier.ofType("Ljava/util/List<+Lcom/sebastian_daschner/jaxrs_test/Model;>;");
         resources.getTypeRepresentations().put(modelListIdentifier, TypeRepresentation.ofCollection(modelListIdentifier, modelRepresentation));
         final TypeIdentifier stringArrayListIdentifier = TypeIdentifier.ofType("Ljava/util/ArrayList<Ljava/lang/String;>;");
-        resources.getTypeRepresentations().put(stringArrayListIdentifier, TypeRepresentation.ofCollection(stringArrayListIdentifier, TypeRepresentation.ofConcrete(stringIdentifier)));
+        resources.getTypeRepresentations().put(stringArrayListIdentifier,
+            TypeRepresentation.ofCollection(stringArrayListIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build()));
 
         resources.setBasePath("rest");
 
@@ -292,17 +308,17 @@ public class ProjectAnalyzerTest {
         properties.put("key", stringIdentifier);
         // All numbers are treat as double (JSON type number)
         properties.put("duke", TypeIdentifier.ofType(Types.DOUBLE));
-        resources.getTypeRepresentations().put(firstIdentifier, TypeRepresentation.ofConcrete(firstIdentifier, properties));
+        resources.getTypeRepresentations().put(firstIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(firstIdentifier).properties(properties).build());
         ResourceMethod twelfthGet = ResourceMethodBuilder.withMethod(HttpMethod.GET).andResponse(200, ResponseBuilder.withResponseBody(firstIdentifier).build()).build();
 
         final TypeIdentifier secondIdentifier = TypeIdentifier.ofDynamic();
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);
-        resources.getTypeRepresentations().put(secondIdentifier, TypeRepresentation.ofConcrete(secondIdentifier, properties));
+        resources.getTypeRepresentations().put(secondIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(secondIdentifier).properties(properties).build());
 
         // TODO type should be Object because JsonArray is interpreted as collection type
         final TypeIdentifier thirdIdentifier = TypeIdentifier.ofDynamic();
-        resources.getTypeRepresentations().put(thirdIdentifier, TypeRepresentation.ofCollection(thirdIdentifier, TypeRepresentation.ofConcrete(stringIdentifier)));
+        resources.getTypeRepresentations().put(thirdIdentifier, TypeRepresentation.ofCollection(thirdIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build()));
         ResourceMethod fifthPost = ResourceMethodBuilder.withMethod(HttpMethod.POST)
                 .andResponse(202, ResponseBuilder.withResponseBody(secondIdentifier).build())
                 .andResponse(500, ResponseBuilder.newBuilder().build())
@@ -316,7 +332,7 @@ public class ProjectAnalyzerTest {
         properties.put("key", stringIdentifier);
         properties.put("duke", stringIdentifier);
         properties.put("hello", stringIdentifier);
-        resources.getTypeRepresentations().put(fourthIdentifier, TypeRepresentation.ofConcrete(fourthIdentifier, properties));
+        resources.getTypeRepresentations().put(fourthIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(fourthIdentifier).properties(properties).build());
         ResourceMethod thirteenthGet = ResourceMethodBuilder.withMethod(HttpMethod.GET).andResponse(200, ResponseBuilder.withResponseBody(fourthIdentifier).build())
                 .build();
         addMethods(resources, "json_tests/info", thirteenthGet);

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/DynamicTypeAnalyzerTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/DynamicTypeAnalyzerTest.java
@@ -117,10 +117,10 @@ public class DynamicTypeAnalyzerTest {
     @Test
     public void testEqualTypes() {
         // should be ignored
-        typeRepresentations.put(STRING_LIST_IDENTIFIER, TypeRepresentation.ofCollection(STRING_LIST_IDENTIFIER, TypeRepresentation.ofConcrete(STRING_IDENTIFIER)));
+        typeRepresentations.put(STRING_LIST_IDENTIFIER, TypeRepresentation.ofCollection(STRING_LIST_IDENTIFIER, TypeRepresentation.ofConcreteBuilder().identifier(STRING_IDENTIFIER).build()));
         final TypeIdentifier modelIdentifier = TypeIdentifier.ofType("com.sebastian_daschner.test.Model");
         final Map<String, TypeIdentifier> modelProperties = Collections.singletonMap("string", TypeUtils.STRING_IDENTIFIER);
-        typeRepresentations.put(modelIdentifier, TypeRepresentation.ofConcrete(modelIdentifier, modelProperties));
+        typeRepresentations.put(modelIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(modelIdentifier).properties(modelProperties).build());
 
         TypeIdentifier identifier = cut.analyze(Json.createArrayBuilder().add("foobar").build());
         final String firstName = identifier.getName();

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/JavaTypeAnalyzerTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/JavaTypeAnalyzerTest.java
@@ -48,7 +48,7 @@ public class JavaTypeAnalyzerTest {
         this.testClassName = testClassName;
         this.expectedIdentifier = expectedIdentifier;
         this.expectedRepresentations = expectedRepresentations;
-        this.classUnderTest = new JavaTypeAnalyzer(actualTypeRepresentations);
+        this.classUnderTest = new JavaTypeAnalyzer(actualTypeRepresentations, new HashMap<>());
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/ResultInterpreterTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/ResultInterpreterTest.java
@@ -16,24 +16,36 @@
 
 package com.sebastian_daschner.jaxrs_analyzer.analysis.results;
 
-import com.sebastian_daschner.jaxrs_analyzer.builder.*;
+import static com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils.STRING_IDENTIFIER;
+import static org.junit.Assert.assertEquals;
+
+import com.sebastian_daschner.jaxrs_analyzer.analysis.javadoc.JavaDocAnalyzerResults;
+import com.sebastian_daschner.jaxrs_analyzer.builder.ClassResultBuilder;
+import com.sebastian_daschner.jaxrs_analyzer.builder.HttpResponseBuilder;
+import com.sebastian_daschner.jaxrs_analyzer.builder.MethodResultBuilder;
+import com.sebastian_daschner.jaxrs_analyzer.builder.ResourceMethodBuilder;
+import com.sebastian_daschner.jaxrs_analyzer.builder.ResponseBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.model.Types;
 import com.sebastian_daschner.jaxrs_analyzer.model.javadoc.MethodComment;
-import com.sebastian_daschner.jaxrs_analyzer.model.rest.*;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.HttpMethod;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.ResourceMethod;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.Resources;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
 import com.sebastian_daschner.jaxrs_analyzer.model.results.ClassResult;
 import com.sebastian_daschner.jaxrs_analyzer.model.results.MethodResult;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils.STRING_IDENTIFIER;
-import static org.junit.Assert.assertEquals;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 
 public class ResultInterpreterTest {
 
@@ -60,7 +72,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -87,7 +99,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -106,7 +118,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -129,7 +141,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -150,7 +162,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -172,7 +184,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -193,7 +205,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -219,7 +231,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -230,7 +242,7 @@ public class ResultInterpreterTest {
         expectedResult.setBasePath("path");
 
         final TypeIdentifier stringListIdentifier = TypeIdentifier.ofType("Ljava/util/List<Ljava/lang/String;>;");
-        final TypeRepresentation stringList = TypeRepresentation.ofCollection(stringListIdentifier, TypeRepresentation.ofConcrete(STRING_IDENTIFIER));
+        final TypeRepresentation stringList = TypeRepresentation.ofCollection(stringListIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(STRING_IDENTIFIER).build());
         expectedResult.getTypeRepresentations().put(stringListIdentifier, stringList);
 
         final ResourceMethod resourceGetMethod = ResourceMethodBuilder.withMethod(HttpMethod.GET)
@@ -246,7 +258,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -258,8 +270,8 @@ public class ResultInterpreterTest {
         final Resources expectedResult = new Resources();
         expectedResult.setBasePath("path");
         final TypeIdentifier identifier = TypeIdentifier.ofType(configurationType);
-        expectedResult.getTypeRepresentations().put(identifier, TypeRepresentation.ofConcrete(identifier,
-                Collections.singletonMap("name", STRING_IDENTIFIER)));
+        expectedResult.getTypeRepresentations().put(identifier,
+            TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(Collections.singletonMap("name", STRING_IDENTIFIER)).build());
 
         final ResourceMethod resourceGetMethod = ResourceMethodBuilder.withMethod(HttpMethod.GET)
                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build())
@@ -276,7 +288,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }
@@ -302,7 +314,7 @@ public class ResultInterpreterTest {
 
         final Set<ClassResult> results = new HashSet<>(Arrays.asList(appPathResult, resClassResult));
 
-        final Resources actualResult = classUnderTest.interpret(results);
+        final Resources actualResult = classUnderTest.interpret(new JavaDocAnalyzerResults(results, new HashMap<>())); // TODO
 
         assertEquals(expectedResult, actualResult);
     }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass1.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass1.java
@@ -57,7 +57,7 @@ public class TestClass1 {
         properties.put("test", TypeUtils.STRING_IDENTIFIER);
         properties.put("int", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass10.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass10.java
@@ -49,7 +49,7 @@ public class TestClass10 {
         properties.put("second", TypeIdentifier.ofType("Ljava/util/Map;"));
         properties.put("third", TypeIdentifier.ofType("Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;"));
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass11.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass11.java
@@ -42,7 +42,7 @@ public class TestClass11 {
         properties.put("second", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
         properties.put("child", identifier);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(identifier, properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass12.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass12.java
@@ -44,13 +44,13 @@ public class TestClass12 {
         properties.put("child", innerTestIdentifier);
 
         final TypeIdentifier testClass12Identifier = expectedIdentifier();
-        final TypeRepresentation testClass12 = TypeRepresentation.ofConcrete(testClass12Identifier, properties);
+        final TypeRepresentation testClass12 = TypeRepresentation.ofConcreteBuilder().identifier(testClass12Identifier).properties(properties).build();
 
         final Map<String, TypeIdentifier> innerProperties = new HashMap<>();
         innerProperties.put("second", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
         innerProperties.put("child", testClass12Identifier);
 
-        final TypeRepresentation innerTestClass = TypeRepresentation.ofConcrete(innerTestIdentifier, innerProperties);
+        final TypeRepresentation innerTestClass = TypeRepresentation.ofConcreteBuilder().identifier(innerTestIdentifier).properties(innerProperties).build();
 
         return new HashSet<>(Arrays.asList(testClass12, innerTestClass));
     }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass13.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass13.java
@@ -69,24 +69,24 @@ public class TestClass13 {
         properties.put("longAndString", longStringIdentifier);
         properties.put("stringAndLong", stringLongIdentifier);
 
-        final TypeRepresentation testClass13 = TypeRepresentation.ofConcrete(expectedIdentifier(), properties);
+        final TypeRepresentation testClass13 = TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build();
 
         final TypeIdentifier listStringIdentifier = TypeIdentifier.ofType("Ljava/util/List<Ljava/lang/String;>;");
-        final TypeRepresentation listString = TypeRepresentation.ofCollection(listStringIdentifier, TypeRepresentation.ofConcrete(stringIdentifier));
+        final TypeRepresentation listString = TypeRepresentation.ofCollection(listStringIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build());
         final TypeIdentifier listLongIdentifier = TypeIdentifier.ofType("Ljava/util/List<Ljava/lang/Long;>;");
-        final TypeRepresentation listLong = TypeRepresentation.ofCollection(listLongIdentifier, TypeRepresentation.ofConcrete(longIdentifier));
+        final TypeRepresentation listLong = TypeRepresentation.ofCollection(listLongIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(longIdentifier).build());
 
         final Map<String, TypeIdentifier> longStringProperties = new HashMap<>();
         longStringProperties.put("a", longIdentifier);
         longStringProperties.put("b", stringIdentifier);
         longStringProperties.put("listA", listLongIdentifier);
-        final TypeRepresentation longString = TypeRepresentation.ofConcrete(longStringIdentifier, longStringProperties);
+        final TypeRepresentation longString = TypeRepresentation.ofConcreteBuilder().identifier(longStringIdentifier).properties(longStringProperties).build();
 
         final Map<String, TypeIdentifier> stringLongProperties = new HashMap<>();
         stringLongProperties.put("a", stringIdentifier);
         stringLongProperties.put("b", longIdentifier);
         stringLongProperties.put("listA", listStringIdentifier);
-        final TypeRepresentation stringLong = TypeRepresentation.ofConcrete(stringLongIdentifier, stringLongProperties);
+        final TypeRepresentation stringLong = TypeRepresentation.ofConcreteBuilder().identifier(stringLongIdentifier).properties(stringLongProperties).build();
 
         return new HashSet<>(Arrays.asList(testClass13, longString, stringLong, listLong, listString));
     }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass14.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass14.java
@@ -73,24 +73,24 @@ public class TestClass14 {
         properties.put("longAndString", longStringIdentifier);
         properties.put("stringAndLong", stringLongIdentifier);
 
-        final TypeRepresentation testClass13 = TypeRepresentation.ofConcrete(expectedIdentifier(), properties);
+        final TypeRepresentation testClass13 = TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build();
 
         final TypeIdentifier listStringIdentifier = TypeIdentifier.ofType("Ljava/util/List<Ljava/lang/String;>;");
-        final TypeRepresentation listString = TypeRepresentation.ofCollection(listStringIdentifier, TypeRepresentation.ofConcrete(stringIdentifier));
+        final TypeRepresentation listString = TypeRepresentation.ofCollection(listStringIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build());
         final TypeIdentifier listLongIdentifier = TypeIdentifier.ofType("Ljava/util/List<Ljava/lang/Long;>;");
-        final TypeRepresentation listLong = TypeRepresentation.ofCollection(listLongIdentifier, TypeRepresentation.ofConcrete(longIdentifier));
+        final TypeRepresentation listLong = TypeRepresentation.ofCollection(listLongIdentifier, TypeRepresentation.ofConcreteBuilder().identifier(longIdentifier).build());
 
         final Map<String, TypeIdentifier> longStringProperties = new HashMap<>();
         longStringProperties.put("a", longIdentifier);
         longStringProperties.put("b", stringIdentifier);
         longStringProperties.put("listA", listLongIdentifier);
-        final TypeRepresentation longString = TypeRepresentation.ofConcrete(longStringIdentifier, longStringProperties);
+        final TypeRepresentation longString = TypeRepresentation.ofConcreteBuilder().identifier(longStringIdentifier).properties(longStringProperties).build();
 
         final Map<String, TypeIdentifier> stringLongProperties = new HashMap<>();
         stringLongProperties.put("a", stringIdentifier);
         stringLongProperties.put("b", longIdentifier);
         stringLongProperties.put("listA", listStringIdentifier);
-        final TypeRepresentation stringLong = TypeRepresentation.ofConcrete(stringLongIdentifier, stringLongProperties);
+        final TypeRepresentation stringLong = TypeRepresentation.ofConcreteBuilder().identifier(stringLongIdentifier).properties(stringLongProperties).build();
 
         return new HashSet<>(Arrays.asList(testClass13, longString, stringLong, listLong, listString));
     }

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass15.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass15.java
@@ -27,7 +27,7 @@ public class TestClass15 extends SuperTestClass1 {
         properties.put("foobar", TypeUtils.STRING_IDENTIFIER);
         properties.put("test", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass16.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass16.java
@@ -22,8 +22,8 @@ public class TestClass16 extends SuperTestClass2 {
         properties.put("world", stringIdentifier);
         properties.put("partner", superTestClass2);
 
-        return new HashSet<>(Arrays.asList(TypeRepresentation.ofConcrete(expectedIdentifier(), properties),
-                TypeRepresentation.ofConcrete(superTestClass2, Collections.singletonMap("hello", stringIdentifier))));
+        return new HashSet<>(Arrays.asList(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build(),
+                TypeRepresentation.ofConcreteBuilder().identifier(superTestClass2).properties(Collections.singletonMap("hello", stringIdentifier)).build()));
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass17.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass17.java
@@ -36,8 +36,8 @@ public class TestClass17 extends SuperTestClass3 {
         properties.put("world", stringIdentifier);
         properties.put("partner", superTestClass3);
 
-        return new HashSet<>(Arrays.asList(TypeRepresentation.ofConcrete(expectedIdentifier(), properties),
-                TypeRepresentation.ofConcrete(superTestClass3, Collections.singletonMap("hello", stringIdentifier))));
+        return new HashSet<>(Arrays.asList(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build(),
+                TypeRepresentation.ofConcreteBuilder().identifier(superTestClass3).properties(Collections.singletonMap("hello", stringIdentifier)).build()));
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass18.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass18.java
@@ -26,7 +26,7 @@ public class TestClass18 extends SuperTestClass4 {
         properties.put("test", TypeUtils.STRING_IDENTIFIER);
         properties.put("partner", identifier);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(identifier, properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass19.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass19.java
@@ -29,7 +29,7 @@ public class TestClass19 extends SuperTestClass5 {
         properties.put("hello", TypeUtils.STRING_IDENTIFIER);
         properties.put("overidden", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass2.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass2.java
@@ -20,9 +20,10 @@ import com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
 
-import javax.xml.bind.annotation.XmlTransient;
 import java.util.Collections;
 import java.util.Set;
+
+import javax.xml.bind.annotation.XmlTransient;
 
 public class TestClass2 {
 
@@ -44,7 +45,9 @@ public class TestClass2 {
     }
 
     public static Set<TypeRepresentation> expectedTypeRepresentations() {
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), Collections.singletonMap("second", TypeUtils.STRING_IDENTIFIER)));
+        return Collections.singleton(
+            TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(Collections.singletonMap("second", TypeUtils.STRING_IDENTIFIER))
+                .build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass20.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass20.java
@@ -30,7 +30,7 @@ public class TestClass20 implements Interface1, Interface2 {
         properties.put("test3", TypeUtils.STRING_IDENTIFIER);
         properties.put("test4", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass21.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass21.java
@@ -44,7 +44,7 @@ public class TestClass21 {
         final TypeIdentifier inner = TypeIdentifier.ofType("Lcom/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass21$InnerTestClass21;");
         properties.put("inner", inner);
 
-        return new HashSet<>(asList(TypeRepresentation.ofConcrete(expectedIdentifier(), properties), TypeRepresentation.ofEnum(inner, "FIRST", "SECOND")));
+        return new HashSet<>(asList(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build(), TypeRepresentation.ofEnum(inner, "FIRST", "SECOND")));
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass22.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass22.java
@@ -63,7 +63,7 @@ public class TestClass22 {
         properties.put("test", TypeUtils.STRING_IDENTIFIER);
         properties.put("int", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass23.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass23.java
@@ -47,7 +47,7 @@ public class TestClass23 {
         properties.put("second", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
         //properties.put("child", identifier); @JsonIgnore
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(identifier, properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass24.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass24.java
@@ -46,7 +46,7 @@ public class TestClass24 {
         properties.put("first", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
 
         final TypeIdentifier testClass24Identifier = expectedIdentifier();
-        final TypeRepresentation testClass24 = TypeRepresentation.ofConcrete(testClass24Identifier, properties);
+        final TypeRepresentation testClass24 = TypeRepresentation.ofConcreteBuilder().identifier(testClass24Identifier).properties(properties).build();
 
 
         return new HashSet<>(Arrays.asList(testClass24));

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass25.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass25.java
@@ -63,7 +63,7 @@ public class TestClass25 {
         properties.put("publicField", TypeUtils.STRING_IDENTIFIER);
         properties.put("int", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass26.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass26.java
@@ -30,7 +30,7 @@ public class TestClass26 extends SuperTestClass26 {
 
         properties.put("foobar", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass27.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass27.java
@@ -34,7 +34,7 @@ public class TestClass27 extends SuperTestClass27 {
 
         properties.put("foobar", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass28.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass28.java
@@ -30,7 +30,7 @@ public class TestClass28 extends SuperTestClass28 {
 
         properties.put("foobar", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass29.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass29.java
@@ -64,7 +64,7 @@ public class TestClass29 {
         properties.put("publicField", TypeUtils.STRING_IDENTIFIER);
         properties.put("int", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass3.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass3.java
@@ -20,10 +20,16 @@ import com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
 import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.*;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -54,9 +60,10 @@ public class TestClass3 {
         properties.put("second", typeIdentifier);
         properties.put("third", anotherInnerIdentifier);
 
-        final TypeRepresentation testClass3 = TypeRepresentation.ofConcrete(expectedIdentifier(), properties);
-        final TypeRepresentation innerClass = TypeRepresentation.ofConcrete(innerClassIdentifier, Collections.singletonMap("name", TypeUtils.STRING_IDENTIFIER));
-        final TypeRepresentation anotherInner = TypeRepresentation.ofConcrete(anotherInnerIdentifier);
+        final TypeRepresentation testClass3 = TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build();
+        final TypeRepresentation innerClass = TypeRepresentation.ofConcreteBuilder().identifier(innerClassIdentifier)
+            .properties(Collections.singletonMap("name", TypeUtils.STRING_IDENTIFIER)).build();
+        final TypeRepresentation anotherInner = TypeRepresentation.ofConcreteBuilder().identifier(anotherInnerIdentifier).build();
         final TypeRepresentation type = TypeRepresentation.ofEnum(typeIdentifier, "ONE", "TWO", "THREE");
 
         return new HashSet<>(Arrays.asList(testClass3, innerClass, anotherInner, type));

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass30.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass30.java
@@ -70,7 +70,7 @@ public class TestClass30 {
         properties.put("int", TypeIdentifier.ofType(Types.PRIMITIVE_INT));
         properties.put("testname", TypeIdentifier.ofType(Types.PRIMITIVE_BOOLEAN));
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass4.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass4.java
@@ -43,7 +43,7 @@ public class TestClass4 {
         properties.put("first", TypeIdentifier.ofType("Ljava/time/LocalDate;"));
         properties.put("second", TypeIdentifier.ofType(Types.DATE));
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass5.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass5.java
@@ -50,8 +50,8 @@ public class TestClass5 {
         properties.put("first", listIdentifier);
         properties.put("second", setIdentifier);
 
-        final TypeRepresentation testClass5 = TypeRepresentation.ofConcrete(expectedIdentifier(), properties);
-        final TypeRepresentation string = TypeRepresentation.ofConcrete(TypeUtils.STRING_IDENTIFIER);
+        final TypeRepresentation testClass5 = TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build();
+        final TypeRepresentation string = TypeRepresentation.ofConcreteBuilder().identifier(TypeUtils.STRING_IDENTIFIER).build();
         final TypeRepresentation listString = TypeRepresentation.ofCollection(listIdentifier, string);
         final TypeRepresentation setString = TypeRepresentation.ofCollection(setIdentifier, string);
 

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass6.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass6.java
@@ -60,7 +60,7 @@ public class TestClass6 {
         properties.put("second", TypeUtils.STRING_IDENTIFIER);
         properties.put("third", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass7.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass7.java
@@ -54,7 +54,7 @@ public class TestClass7 {
         properties.put("second", TypeUtils.STRING_IDENTIFIER);
         properties.put("third", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass8.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/analysis/results/testclasses/typeanalyzer/TestClass8.java
@@ -51,7 +51,7 @@ public class TestClass8 {
 
         properties.put("third", TypeUtils.STRING_IDENTIFIER);
 
-        return Collections.singleton(TypeRepresentation.ofConcrete(expectedIdentifier(), properties));
+        return Collections.singleton(TypeRepresentation.ofConcreteBuilder().identifier(expectedIdentifier()).properties(properties).build());
     }
 
     public static TypeIdentifier expectedIdentifier() {

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppenderTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/JsonRepresentationAppenderTest.java
@@ -32,13 +32,13 @@ public class JsonRepresentationAppenderTest {
 
     @Test
     public void testVisitPrimitive() {
-        TypeRepresentation.ofConcrete(TypeIdentifier.ofType(Types.STRING)).accept(cut);
+        TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofType(Types.STRING)).build().accept(cut);
         assertThat(builder.toString(), is("\"string\""));
     }
 
     @Test
     public void testMissingRepresentation() {
-        TypeRepresentation.ofCollection(STRING_LIST_IDENTIFIER, TypeRepresentation.ofConcrete(STRING_IDENTIFIER)).accept(cut);
+        TypeRepresentation.ofCollection(STRING_LIST_IDENTIFIER, TypeRepresentation.ofConcreteBuilder().identifier(STRING_IDENTIFIER).build()).accept(cut);
         assertThat(builder.toString(), is("[\"string\"]"));
     }
 
@@ -56,7 +56,7 @@ public class JsonRepresentationAppenderTest {
 
     @Test
     public void testVisitSimpleList() {
-        final TypeRepresentation stringRepresentation = TypeRepresentation.ofConcrete(STRING_IDENTIFIER);
+        final TypeRepresentation stringRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(STRING_IDENTIFIER).build();
         final TypeRepresentation listRepresentation = TypeRepresentation.ofCollection(STRING_LIST_IDENTIFIER, stringRepresentation);
         representations.put(STRING_LIST_IDENTIFIER, listRepresentation);
 
@@ -80,7 +80,7 @@ public class JsonRepresentationAppenderTest {
     public void testVisitMultipleList() {
         final TypeIdentifier identifier = TypeIdentifier.ofType("java.util.List<java.util.List<java.lang.String>>");
         final TypeRepresentation representation = TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofCollection(STRING_LIST_IDENTIFIER,
-                TypeRepresentation.ofConcrete(STRING_IDENTIFIER)));
+                TypeRepresentation.ofConcreteBuilder().identifier(STRING_IDENTIFIER).build()));
         representations.put(identifier, representation);
 
         representation.accept(cut);
@@ -97,11 +97,11 @@ public class JsonRepresentationAppenderTest {
 
     @Test
     public void testVisitDynamic() {
-        TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic()).accept(cut);
+        TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).build().accept(cut);
         assertThat(builder.toString(), is("{}"));
 
         clear(builder);
-        TypeRepresentation.ofCollection(TypeIdentifier.ofDynamic(), TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic())).accept(cut);
+        TypeRepresentation.ofCollection(TypeIdentifier.ofDynamic(), TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).build()).accept(cut);
         assertThat(builder.toString(), is("[{}]"));
     }
 
@@ -114,7 +114,7 @@ public class JsonRepresentationAppenderTest {
         properties.put("hello", STRING_IDENTIFIER);
         properties.put("abc", STRING_IDENTIFIER);
         properties.put("enumeration", enumIdentifier);
-        final TypeRepresentation representation = TypeRepresentation.ofConcrete(identifier, properties);
+        final TypeRepresentation representation = TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build();
         final TypeRepresentation enumRepresentation = TypeRepresentation.ofEnum(identifier, "FOO", "BAR", "BAZ");
 
         representations.put(identifier, representation);
@@ -131,7 +131,7 @@ public class JsonRepresentationAppenderTest {
         properties.put("hello", STRING_IDENTIFIER);
         properties.put("abc", STRING_IDENTIFIER);
         properties.put("model", identifier);
-        final TypeRepresentation representation = TypeRepresentation.ofConcrete(identifier, properties);
+        final TypeRepresentation representation = TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build();
 
         representations.put(identifier, representation);
         representation.accept(cut);
@@ -148,7 +148,7 @@ public class JsonRepresentationAppenderTest {
         properties.put("world", INT_IDENTIFIER);
         properties.put("abc", STRING_IDENTIFIER);
         properties.put("model", modelIdentifier);
-        final TypeRepresentation dateRepresentation = TypeRepresentation.ofConcrete(dateIdentifier, properties);
+        final TypeRepresentation dateRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(dateIdentifier).properties(properties).build();
         representations.put(dateIdentifier, dateRepresentation);
 
         properties = new HashMap<>();
@@ -156,7 +156,7 @@ public class JsonRepresentationAppenderTest {
         properties.put("hello", STRING_IDENTIFIER);
         properties.put("abc", STRING_IDENTIFIER);
         properties.put("model", modelIdentifier);
-        final TypeRepresentation objectRepresentation = TypeRepresentation.ofConcrete(objectIdentifier, properties);
+        final TypeRepresentation objectRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(objectIdentifier).properties(properties).build();
         representations.put(objectIdentifier, objectRepresentation);
 
         properties = new HashMap<>();
@@ -165,7 +165,7 @@ public class JsonRepresentationAppenderTest {
         properties.put("abc", STRING_IDENTIFIER);
         properties.put("date", dateIdentifier);
         properties.put("object", objectIdentifier);
-        final TypeRepresentation modelRepresentation = TypeRepresentation.ofConcrete(modelIdentifier, properties);
+        final TypeRepresentation modelRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(modelIdentifier).properties(properties).build();
         representations.put(modelIdentifier, modelRepresentation);
 
         // date
@@ -208,7 +208,7 @@ public class JsonRepresentationAppenderTest {
         properties.put("hello", STRING_IDENTIFIER);
         properties.put("abc", STRING_IDENTIFIER);
         properties.put("model", modelIdentifier);
-        final TypeRepresentation modelRepresentation = TypeRepresentation.ofConcrete(modelIdentifier, properties);
+        final TypeRepresentation modelRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(modelIdentifier).properties(properties).build();
         representations.put(modelIdentifier, modelRepresentation);
 
         modelRepresentation.accept(cut);
@@ -228,13 +228,13 @@ public class JsonRepresentationAppenderTest {
         Map<String, TypeIdentifier> properties = new HashMap<>();
         properties.put("world", INT_IDENTIFIER);
         properties.put("model", secondModelIdentifier);
-        final TypeRepresentation firstModelRepresentation = TypeRepresentation.ofConcrete(firstModelIdentifier, properties);
+        final TypeRepresentation firstModelRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(firstModelIdentifier).properties(properties).build();
         representations.put(firstModelIdentifier, firstModelRepresentation);
 
         properties = new HashMap<>();
         properties.put("hello", STRING_IDENTIFIER);
         properties.put("model", firstModelIdentifier);
-        final TypeRepresentation secondModelRepresentation = TypeRepresentation.ofConcrete(secondModelIdentifier, properties);
+        final TypeRepresentation secondModelRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(secondModelIdentifier).properties(properties).build();
         representations.put(secondModelIdentifier, secondModelRepresentation);
 
         firstModelRepresentation.accept(cut);

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/asciidoc/AsciiDocBackendTest.java
@@ -1,11 +1,22 @@
 package com.sebastian_daschner.jaxrs_analyzer.backend.asciidoc;
 
+import static com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils.ENUM_IDENTIFIER;
+import static com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils.MODEL_IDENTIFIER;
+import static com.sebastian_daschner.jaxrs_analyzer.backend.StringBackend.INLINE_PRETTIFY;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+
 import com.sebastian_daschner.jaxrs_analyzer.backend.Backend;
 import com.sebastian_daschner.jaxrs_analyzer.builder.ResourceMethodBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.builder.ResourcesBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.builder.ResponseBuilder;
 import com.sebastian_daschner.jaxrs_analyzer.model.Types;
-import com.sebastian_daschner.jaxrs_analyzer.model.rest.*;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.HttpMethod;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.Project;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.Resources;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeIdentifier;
+import com.sebastian_daschner.jaxrs_analyzer.model.rest.TypeRepresentation;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -14,12 +25,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
-
-import static com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils.ENUM_IDENTIFIER;
-import static com.sebastian_daschner.jaxrs_analyzer.analysis.results.TypeUtils.MODEL_IDENTIFIER;
-import static com.sebastian_daschner.jaxrs_analyzer.backend.StringBackend.INLINE_PRETTIFY;
-import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class AsciiDocBackendTest {
@@ -106,7 +111,7 @@ public class AsciiDocBackendTest {
         properties.put("another", intIdentifier);
         final Resources getRestRes1Json = ResourcesBuilder.withBase("rest")
                 .andTypeRepresentation(identifier,
-                        TypeRepresentation.ofConcrete(identifier, properties))
+                        TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build())
                 .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                         .andResponse(200,
                                 ResponseBuilder.withResponseBody(
@@ -145,8 +150,8 @@ public class AsciiDocBackendTest {
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);
         properties.put("another", intIdentifier);
-        add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
+        add(data, ResourcesBuilder.withBase("rest").andTypeRepresentation(identifier, TypeRepresentation
+                .ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "= REST resources of project name\n" +
@@ -164,7 +169,7 @@ public class AsciiDocBackendTest {
 
         identifier = TypeIdentifier.ofDynamic();
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(stringIdentifier)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "= REST resources of project name\n" +
@@ -185,8 +190,8 @@ public class AsciiDocBackendTest {
         identifier = TypeIdentifier.ofDynamic();
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);
-        add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
+        add(data, ResourcesBuilder.withBase("rest").andTypeRepresentation(identifier, TypeRepresentation
+                .ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "= REST resources of project name\n" +
@@ -208,7 +213,7 @@ public class AsciiDocBackendTest {
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties))
+                .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build())
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(MODEL_IDENTIFIER).build()).build()).build(),
                 "= REST resources of project name\n" +
@@ -230,8 +235,8 @@ public class AsciiDocBackendTest {
         properties = new HashMap<>();
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
-        add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+        add(data, ResourcesBuilder.withBase("rest").andTypeRepresentation(identifier,
+            TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "= REST resources of project name\n" +
@@ -273,8 +278,8 @@ public class AsciiDocBackendTest {
         properties = new HashMap<>();
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
-        add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+        add(data, ResourcesBuilder.withBase("rest").andTypeRepresentation(identifier,
+            TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.POST).andRequestBodyType(identifier).andFormParam("form", MODEL_IDENTIFIER.getType())
                                 .andAcceptMediaTypes("application/json").andResponse(201, ResponseBuilder.newBuilder().andHeaders("Location").build()).build()).build(),
                 "= REST resources of project name\n" +
@@ -294,8 +299,8 @@ public class AsciiDocBackendTest {
                         "==== `201 Created`\n" +
                         "*Header*: `Location` + \n\n", false);
 
-        add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+        add(data, ResourcesBuilder.withBase("rest").andTypeRepresentation(identifier,
+            TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.POST).andRequestBodyType(identifier).andQueryParam("query", Types.PRIMITIVE_INT)
                                 .andAcceptMediaTypes("application/json").andResponse(201, ResponseBuilder.newBuilder().andHeaders("Location").build()).build())
                         .andResource("res2", ResourceMethodBuilder.withMethod(HttpMethod.GET).andResponse(200, ResponseBuilder.newBuilder().build()).build()).build(),

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/markdown/MarkdownBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/markdown/MarkdownBackendTest.java
@@ -113,7 +113,7 @@ public class MarkdownBackendTest {
         properties.put("another", intIdentifier);
         final Resources getRestRes1Json = ResourcesBuilder.withBase("rest")
                 .andTypeRepresentation(identifier,
-                        TypeRepresentation.ofConcrete(identifier, properties))
+                        TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build())
                 .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                         .andResponse(200,
                                 ResponseBuilder.withResponseBody(
@@ -153,7 +153,7 @@ public class MarkdownBackendTest {
         properties.put("key", stringIdentifier);
         properties.put("another", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "# REST resources of project name\n\n" +
@@ -171,7 +171,7 @@ public class MarkdownBackendTest {
 
         identifier = TypeIdentifier.ofDynamic();
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(stringIdentifier)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "# REST resources of project name\n\n" +
@@ -193,7 +193,7 @@ public class MarkdownBackendTest {
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "# REST resources of project name\n\n" +
@@ -215,7 +215,7 @@ public class MarkdownBackendTest {
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties))
+                        .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build())
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(MODEL_IDENTIFIER).build()).build()).build(),
                 "# REST resources of project name\n\n" +
@@ -238,7 +238,7 @@ public class MarkdownBackendTest {
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "# REST resources of project name\n\n" +
@@ -257,7 +257,7 @@ public class MarkdownBackendTest {
                         "```javascript\n" + "[{\"name\":\"string\",\"value\":0}]\n" + "```\n\n\n\n", false);
 
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.POST).andRequestBodyType(identifier).andFormParam("form", MODEL_IDENTIFIER.getType())
                                 .andAcceptMediaTypes("application/json").andResponse(201, ResponseBuilder.newBuilder().andHeaders("Location").build()).build()).build(),
                 "# REST resources of project name\n\n" +
@@ -278,7 +278,7 @@ public class MarkdownBackendTest {
                         "*Header*: `Location` + \n\n", false);
 
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res1", ResourceMethodBuilder.withMethod(HttpMethod.POST).andRequestBodyType(identifier).andQueryParam("query", Types.PRIMITIVE_INT)
                                 .andAcceptMediaTypes("application/json").andResponse(201, ResponseBuilder.newBuilder().andHeaders("Location").build()).build())
                         .andResource("res2", ResourceMethodBuilder.withMethod(HttpMethod.GET).andResponse(200, ResponseBuilder.newBuilder().build()).build()).build(),

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/plaintext/PlainTextBackendTest.java
@@ -77,7 +77,7 @@ public class PlainTextBackendTest {
         properties.put("key", stringIdentifier);
         properties.put("another", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofConcrete(identifier, properties))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build())
                         .andResource("res2", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "REST resources of project name:\n" +
@@ -98,7 +98,7 @@ public class PlainTextBackendTest {
         properties.put("key", stringIdentifier);
         properties.put("another", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(properties).build()))
                         .andResource("res3", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "REST resources of project name:\n" +
@@ -116,7 +116,7 @@ public class PlainTextBackendTest {
 
         identifier = TypeIdentifier.ofDynamic();
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(stringIdentifier)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build()))
                         .andResource("res4", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "REST resources of project name:\n" +
@@ -136,7 +136,7 @@ public class PlainTextBackendTest {
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(properties).build()))
                         .andResource("res5", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "REST resources of project name:\n" +
@@ -156,7 +156,7 @@ public class PlainTextBackendTest {
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties))
+                        .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build())
                         .andResource("res6", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(MODEL_IDENTIFIER).build()).build()).build(),
                 "REST resources of project name:\n" +
@@ -177,7 +177,7 @@ public class PlainTextBackendTest {
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res7", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "REST resources of project name:\n" +
@@ -194,7 +194,7 @@ public class PlainTextBackendTest {
                         "    [{\"name\":\"string\",\"value\":0}]\n\n\n");
 
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res8", ResourceMethodBuilder.withMethod(HttpMethod.POST).andRequestBodyType(identifier).andFormParam("form", MODEL_IDENTIFIER.getType())
                                 .andAcceptMediaTypes("application/json").andResponse(201, ResponseBuilder.newBuilder().andHeaders("Location").build()).build()).build(),
                 "REST resources of project name:\n" +
@@ -213,7 +213,7 @@ public class PlainTextBackendTest {
                         "   Header: Location\n\n\n");
 
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res9", ResourceMethodBuilder.withMethod(HttpMethod.POST).andRequestBodyType(identifier).andQueryParam("query", Types.PRIMITIVE_INT)
                                 .andAcceptMediaTypes("application/json").andResponse(201, ResponseBuilder.newBuilder().andHeaders("Location").build()).build())
                         .andResource("res10", ResourceMethodBuilder.withMethod(HttpMethod.GET).andResponse(200, ResponseBuilder.newBuilder().build()).build()).build(),

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/backend/swagger/SwaggerBackendTest.java
@@ -101,7 +101,7 @@ public class SwaggerBackendTest {
         identifier = TypeIdentifier.ofDynamic();
         properties.put("key", stringIdentifier);
         properties.put("another", intIdentifier);
-        add(data, ResourcesBuilder.withBase("rest").andTypeRepresentation(identifier, TypeRepresentation.ofConcrete(identifier, properties))
+        add(data, ResourcesBuilder.withBase("rest").andTypeRepresentation(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build())
                         .andResource("res2", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res2\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"$ref\":\"#/definitions/JsonObject\"}}}}}},\"definitions\":{\"JsonObject\":{\"properties\":{\"another\":{\"type\":\"integer\"},\"key\":{\"type\":\"string\"}}}}}");
@@ -112,7 +112,7 @@ public class SwaggerBackendTest {
         properties.put("key", stringIdentifier);
         properties.put("another", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(properties).build()))
                         .andResource("res3", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res3\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/JsonObject_2\"}}}}}}},\"definitions\":{\"JsonObject_2\":{\"properties\":{\"another\":{\"type\":\"integer\"},\"key\":{\"type\":\"string\"}}}}}");
@@ -120,7 +120,7 @@ public class SwaggerBackendTest {
         resetTypeIdentifierCounter();
         identifier = TypeIdentifier.ofDynamic();
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(stringIdentifier)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(stringIdentifier).build()))
                         .andResource("res4", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res4\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}}}},\"definitions\":{}}");
@@ -130,7 +130,7 @@ public class SwaggerBackendTest {
         properties = new HashMap<>();
         properties.put("key", stringIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(identifier, properties)))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build()))
                         .andResource("res5", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res5\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/JsonObject\"}}}}}}},\"definitions\":{\"JsonObject\":{\"properties\":{\"key\":{\"type\":\"string\"}}}}}");
@@ -139,14 +139,14 @@ public class SwaggerBackendTest {
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties))
+                        .andTypeRepresentation(MODEL_IDENTIFIER, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build())
                         .andResource("res6", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(MODEL_IDENTIFIER).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res6\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"$ref\":\"#/definitions/Model\"}}}}}},\"definitions\":{\"Model\":{\"properties\":{\"name\":{\"type\":\"string\"},\"value\":{\"type\":\"integer\"}}}}}");
 
         identifier = TypeIdentifier.ofType("Ljavax/ws/rs/core/StreamingOutput;");
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(identifier, TypeRepresentation.ofConcrete(identifier))
+                        .andTypeRepresentation(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).build())
                         .andResource("res7", ResourceMethodBuilder.withMethod(HttpMethod.GET)
                                 .andResponse(200, ResponseBuilder.withResponseBody(identifier).build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res7\":{\"get\":{\"consumes\":[],\"produces\":[],\"parameters\":[],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{},\"schema\":{\"$ref\":\"#/definitions/StreamingOutput\"}}}}}},\"definitions\":{\"StreamingOutput\":{\"properties\":{}}}}");
@@ -156,7 +156,7 @@ public class SwaggerBackendTest {
         properties.put("name", stringIdentifier);
         properties.put("value", intIdentifier);
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(MODEL_IDENTIFIER, TypeRepresentation.ofConcrete(MODEL_IDENTIFIER, properties)))
+                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(MODEL_IDENTIFIER, TypeRepresentation.ofConcreteBuilder().identifier(MODEL_IDENTIFIER).properties(properties).build()))
                         .andResource("res8", ResourceMethodBuilder.withMethod(HttpMethod.POST).andRequestBodyType(dynamicIdentifier).andAcceptMediaTypes("application/json")
                                 .andResponse(201, ResponseBuilder.newBuilder().andHeaders("Location").build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res8\":{\"post\":{\"consumes\":[\"application/json\"],\"produces\":[],\"parameters\":[{\"name\":\"body\",\"in\":\"body\",\"required\":true,\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Model\"}}}],\"responses\":{\"201\":{\"description\":\"Created\",\"headers\":{\"Location\":{\"type\":\"string\"}}}}}}},\"definitions\":{\"Model\":{\"properties\":{\"name\":{\"type\":\"string\"},\"value\":{\"type\":\"integer\"}}}}}");
@@ -210,19 +210,19 @@ public class SwaggerBackendTest {
 
         // query parameter tests
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(identifier, properties)))
+                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build()))
                         .andResource("res15", ResourceMethodBuilder.withMethod(HttpMethod.GET).andQueryParam("value", "Ljava/lang/Integer;").andAcceptMediaTypes("application/json")
                                 .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res15\":{\"get\":{\"consumes\":[\"application/json\"],\"produces\":[],\"parameters\":[{\"type\":\"integer\",\"name\":\"value\",\"in\":\"query\",\"required\":true}],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{\"Location\":{\"type\":\"string\"}},\"schema\":{\"type\":\"string\"}}}}}},\"definitions\":{}}");
 
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(identifier, properties)))
+                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build()))
                         .andResource("res16", ResourceMethodBuilder.withMethod(HttpMethod.GET).andQueryParam("value", "Ljava/lang/Integer;", "test").andAcceptMediaTypes("application/json")
                                 .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res16\":{\"get\":{\"consumes\":[\"application/json\"],\"produces\":[],\"parameters\":[{\"type\":\"integer\",\"name\":\"value\",\"in\":\"query\",\"required\":false,\"default\":\"test\"}],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{\"Location\":{\"type\":\"string\"}},\"schema\":{\"type\":\"string\"}}}}}},\"definitions\":{}}");
 
         add(data, ResourcesBuilder.withBase("rest")
-                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcrete(identifier, properties)))
+                        .andTypeRepresentation(dynamicIdentifier, TypeRepresentation.ofCollection(identifier, TypeRepresentation.ofConcreteBuilder().identifier(identifier).properties(properties).build()))
                         .andResource("res17", ResourceMethodBuilder.withMethod(HttpMethod.GET).andQueryParam("value", "Ljava/lang/Integer;").andQueryParam("name", "Ljava/lang/String;", "foobar").andAcceptMediaTypes("application/json")
                                 .andResponse(200, ResponseBuilder.withResponseBody(TypeIdentifier.ofType(Types.STRING)).andHeaders("Location").build()).build()).build(),
                 "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0\",\"title\":\"project name\"},\"host\":\"example.com\",\"basePath\":\"/rest\",\"schemes\":[\"http\"],\"paths\":{\"/res17\":{\"get\":{\"consumes\":[\"application/json\"],\"produces\":[],\"parameters\":[{\"type\":\"string\",\"name\":\"name\",\"in\":\"query\",\"required\":false,\"default\":\"foobar\"},{\"type\":\"integer\",\"name\":\"value\",\"in\":\"query\",\"required\":true}],\"responses\":{\"200\":{\"description\":\"OK\",\"headers\":{\"Location\":{\"type\":\"string\"}},\"schema\":{\"type\":\"string\"}}}}}},\"definitions\":{}}");

--- a/src/test/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/CollectionTypeRepresentationTest.java
+++ b/src/test/java/com/sebastian_daschner/jaxrs_analyzer/model/rest/CollectionTypeRepresentationTest.java
@@ -15,15 +15,15 @@ public class CollectionTypeRepresentationTest {
 
     @Test
     public void testContentEqualsConcrete() {
-        final TypeRepresentation.ConcreteTypeRepresentation stringRepresentation = (TypeRepresentation.ConcreteTypeRepresentation) TypeRepresentation.ofConcrete(TypeIdentifier.ofType(Types.STRING));
-        final TypeRepresentation.ConcreteTypeRepresentation objectRepresentation = (TypeRepresentation.ConcreteTypeRepresentation) TypeRepresentation.ofConcrete(TypeIdentifier.ofType(Types.OBJECT));
+        final TypeRepresentation.ConcreteTypeRepresentation stringRepresentation = (TypeRepresentation.ConcreteTypeRepresentation) TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofType(Types.STRING)).build();
+        final TypeRepresentation.ConcreteTypeRepresentation objectRepresentation = (TypeRepresentation.ConcreteTypeRepresentation) TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofType(Types.OBJECT)).build();
 
         assertTrue(stringRepresentation.contentEquals(objectRepresentation.getProperties()));
 
         final Map<String, TypeIdentifier> firstProperties = new HashMap<>();
         firstProperties.put("hello", STRING_IDENTIFIER);
         firstProperties.put("world", INT_IDENTIFIER);
-        final TypeRepresentation.ConcreteTypeRepresentation firstRepresentation = (TypeRepresentation.ConcreteTypeRepresentation) TypeRepresentation.ofConcrete(OBJECT_IDENTIFIER, firstProperties);
+        final TypeRepresentation.ConcreteTypeRepresentation firstRepresentation = (TypeRepresentation.ConcreteTypeRepresentation) TypeRepresentation.ofConcreteBuilder().identifier(OBJECT_IDENTIFIER).properties(firstProperties).build();
 
         final Map<String, TypeIdentifier> secondProperties = new HashMap<>();
         secondProperties.put("hello", STRING_IDENTIFIER);
@@ -38,10 +38,10 @@ public class CollectionTypeRepresentationTest {
         firstProperties.put("hello", STRING_IDENTIFIER);
         firstProperties.put("world", INT_IDENTIFIER);
 
-        final TypeRepresentation firstRepresentation = TypeRepresentation.ofConcrete(OBJECT_IDENTIFIER, firstProperties);
-        final TypeRepresentation secondRepresentation = TypeRepresentation.ofConcrete(OBJECT_IDENTIFIER, Collections.emptyMap());
-        final TypeRepresentation thirdRepresentation = TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), new HashMap<>(firstProperties));
-        final TypeRepresentation fourthRepresentation = TypeRepresentation.ofConcrete(TypeIdentifier.ofDynamic(), new HashMap<>(firstProperties));
+        final TypeRepresentation firstRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(OBJECT_IDENTIFIER).properties(firstProperties).build();
+        final TypeRepresentation secondRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(OBJECT_IDENTIFIER).properties(Collections.emptyMap()).build();
+        final TypeRepresentation thirdRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(new HashMap<>(firstProperties)).build();
+        final TypeRepresentation fourthRepresentation = TypeRepresentation.ofConcreteBuilder().identifier(TypeIdentifier.ofDynamic()).properties(new HashMap<>(firstProperties)).build();
 
         final TypeRepresentation.CollectionTypeRepresentation firstCollection = (TypeRepresentation.CollectionTypeRepresentation) TypeRepresentation.ofCollection(TypeIdentifier.ofDynamic(), firstRepresentation);
         final TypeRepresentation.CollectionTypeRepresentation secondCollection = (TypeRepresentation.CollectionTypeRepresentation) TypeRepresentation.ofCollection(TypeIdentifier.ofDynamic(), secondRepresentation);


### PR DESCRIPTION
Ensures that the JavaDocs from the POJOs which represent the JSON models (i.e. the POJOs representing the request and response objects) are captured, so that these can be used in the Swagger model 'description' fields:

![Swagger description example](https://user-images.githubusercontent.com/8782943/73459663-29352100-436f-11ea-958d-7ce1eeabea13.png)

I know this sort of thing was discussed in https://github.com/sdaschner/jaxrs-analyzer/issues/128, and it does seem like using JavaDocs makes the most sense for this usecase (especially because the JavaDocs within a 'JSON POJO' will be very unlikely to contain anything programmatically important to other developers).

A lot of files were changed here due to implementing a builder pattern instead of doing `TypeRepresentation.ofConcrete` (the alternative would have been quite messy), but the core changes are to capture extra data in `MemberParameterTag` and `TypeRepresentation`, and then use this in the Swagger `SchemaBuilder` as appropriate.